### PR TITLE
CA-90 When confirming a location, need to know which segments will end up being adjusted

### DIFF
--- a/crCore/src/main/java/com/clueride/service/Network.java
+++ b/crCore/src/main/java/com/clueride/service/Network.java
@@ -20,6 +20,7 @@ package com.clueride.service;
 import java.util.List;
 
 import com.clueride.domain.GeoNode;
+import com.clueride.feature.LineFeature;
 import com.clueride.feature.TrackFeature;
 
 /**
@@ -48,4 +49,6 @@ public interface Network {
      * may now be committed to the memory space which serves requests.
      */
     void storesReadyForPublishing();
+
+    List<LineFeature> getLineFeaturesForNodeId(Integer pointId);
 }

--- a/crCore/src/main/java/com/clueride/service/NodeService.java
+++ b/crCore/src/main/java/com/clueride/service/NodeService.java
@@ -56,4 +56,6 @@ public interface NodeService {
     String showAllNodes();
 
     String getRecGeometry(Integer recId);
+
+    String getMatchingSegments(Integer pointId);
 }

--- a/crMain/src/main/java/com/clueride/rest/Nodes.java
+++ b/crMain/src/main/java/com/clueride/rest/Nodes.java
@@ -117,4 +117,10 @@ public class Nodes {
         return nodeService.showAllNodes();
     }
 
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Path("segment")
+    public String getMatchingSegments(@QueryParam("pointId") Integer pointId) {
+        return nodeService.getMatchingSegments(pointId);
+    }
 }

--- a/crMain/src/main/webapp/js/node/showNodes.html
+++ b/crMain/src/main/webapp/js/node/showNodes.html
@@ -1,6 +1,7 @@
 <div class="showNodes, dataview" ng-controller="NodeEditController as vm">
     <div ng-show="vm.editStatus.editInProgress">
         Editing Node {{vm.editStatus.editPointId}} <br>
+        Matching Edge IDs: {{vm.editStatus.matchingEdgeIds}} <br>
         Current Location: {{vm.editStatus.editPointLatLng}} <br>
         <button ng-click="acceptEdit()">Accept</button>
         <button ng-click="cancelEdit()">Cancel</button>


### PR DESCRIPTION
After bringing in a new set of JSON features to be rendered, learned that setting the
opacity on the layer wasn't sufficient to keep the target marker from being re-rendered.  Have set this up here (function makeNodeEditable()) to move the marker to (0.0, 0.0) temporarily.