### PR TITLE
Fix Build from moving to Java 8

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -80,6 +80,12 @@
             <artifactId>jackson-databind</artifactId>
             <version>2.6.3</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/javax.mail/javax.mail-api -->
+        <dependency>
+            <groupId>javax.mail</groupId>
+            <artifactId>javax.mail-api</artifactId>
+            <version>1.5.6</version>
+        </dependency>
     </dependencies>
   
 </project>


### PR DESCRIPTION
Needed an explicit dependency for the javax.mail API.