### PR TITLE
CA-293: Validation of Auth Token

### DIFF
--- a/crCore/src/main/java/com/clueride/infrastructure/AuthenticationFilter.java
+++ b/crCore/src/main/java/com/clueride/infrastructure/AuthenticationFilter.java
@@ -20,8 +20,8 @@ package com.clueride.infrastructure;
 import java.io.IOException;
 
 import javax.annotation.Priority;
+import javax.inject.Inject;
 import javax.ws.rs.HttpMethod;
-import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.Priorities;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
@@ -29,6 +29,8 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 
 import org.apache.log4j.Logger;
+
+import com.clueride.service.TokenService;
 
 /**
  * Allows picking up Authorization headers and extracting the Principal.
@@ -40,14 +42,19 @@ import org.apache.log4j.Logger;
 public class AuthenticationFilter implements ContainerRequestFilter {
     private static final Logger LOGGER = Logger.getLogger(AuthenticationFilter.class);
 
-    public AuthenticationFilter() {
+    private final TokenService tokenService;
+
+    @Inject
+    public AuthenticationFilter(
+            TokenService tokenService
+    ) {
         super();
+        this.tokenService = tokenService;
         LOGGER.info("Instantiating my Auth");
     }
 
     @Override
     public void filter(ContainerRequestContext requestContext) throws IOException {
-        System.out.println("Checking Auth Header inside filter");
         if (requestContext.getMethod().equals(HttpMethod.OPTIONS)) {
             /* Free pass for OPTIONS requests? */
             LOGGER.info("Allowing OPTIONS request");
@@ -59,27 +66,34 @@ public class AuthenticationFilter implements ContainerRequestFilter {
 
         // Check if the HTTP Authorization header is present and formatted correctly
         if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
-            throw new NotAuthorizedException("Authorization header must be provided");
+            requestContext.abortWith(
+                    Response.status(Response.Status.UNAUTHORIZED).build());
         }
 
         // Extract the token from the HTTP Authorization header
         String token = authorizationHeader.substring("Bearer".length()).trim();
 
-        LOGGER.error("Retrieved token: " + token);
+        if (token.equals("GuestToken")) {
+            /* Respond with a replacement token. */
+            requestContext.abortWith(
+                    Response
+                            .status(Response.Status.OK)
+                            .header(
+                                    HttpHeaders.AUTHORIZATION,
+                                    "Bearer " + tokenService.generateSignedToken())
+                            .build()
+            );
+            return;
+        }
 
         try {
 
             // Validate the token
-            validateToken(token);
+            tokenService.validateToken(token);
 
         } catch (Exception e) {
             requestContext.abortWith(
                     Response.status(Response.Status.UNAUTHORIZED).build());
         }
-    }
-
-    private void validateToken(String token) throws Exception {
-        // Check if it was issued by the server and if it's not expired
-        // Throw an Exception if the token is invalid
     }
 }

--- a/crCore/src/main/java/com/clueride/infrastructure/CorsFilter.java
+++ b/crCore/src/main/java/com/clueride/infrastructure/CorsFilter.java
@@ -71,6 +71,12 @@ public class CorsFilter implements Filter {
                         .toString()
         );
 
+        response.setHeader(
+                /* Custom header for Clue Ride. */
+                "Access-Control-Expose-Headers",
+                "Authentication-Token,"
+        );
+
         filterChain.doFilter(request, response);
     }
 

--- a/crCore/src/main/java/com/clueride/service/TokenService.java
+++ b/crCore/src/main/java/com/clueride/service/TokenService.java
@@ -33,4 +33,10 @@ public interface TokenService {
      * Throws exception if the token is invalid and decodes the passed token.
      */
     DecodedJWT verifyToken(String token);
+
+    /**
+     * Throws exception if the token isn't acceptable by this application.
+     * @param token representing a given principal; should be issued by this app.
+     */
+    void validateToken(String token);
 }

--- a/crCore/src/main/java/com/clueride/service/TokenServiceJwt.java
+++ b/crCore/src/main/java/com/clueride/service/TokenServiceJwt.java
@@ -22,7 +22,9 @@ import java.io.UnsupportedEncodingException;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.InvalidClaimException;
 import com.auth0.jwt.exceptions.JWTCreationException;
+import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.DecodedJWT;
 
 import static com.auth0.jwt.algorithms.Algorithm.HMAC256;
@@ -67,5 +69,14 @@ public class TokenServiceJwt implements TokenService {
                 .withIssuer(ISSUER)
                 .build(); //Reusable verifier instance
         return verifier.verify(token);
+    }
+
+    @Override
+    public void validateToken(String token) {
+        DecodedJWT jwt = verifyToken(token);
+        Claim principalClaim = jwt.getHeaderClaim("principal");
+        if (principalClaim.isNull()) {
+            throw new InvalidClaimException("Unable to verify token's principal");
+        }
     }
 }

--- a/crCore/src/test/java/com/clueride/CoreGuiceModuleTest.java
+++ b/crCore/src/test/java/com/clueride/CoreGuiceModuleTest.java
@@ -52,7 +52,6 @@ import com.clueride.service.OutingService;
 import com.clueride.service.OutingServiceImpl;
 import com.clueride.service.RecommendationService;
 import com.clueride.service.TokenService;
-import com.clueride.service.TokenServiceJwt;
 import static java.util.Arrays.asList;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -93,6 +92,9 @@ public class CoreGuiceModuleTest extends AbstractModule {
     @Mock
     private RecommendationService recommendationService;
 
+    @Mock
+    private TokenService tokenService;
+
     @Override
     protected void configure() {
         initMocks(this);
@@ -108,7 +110,7 @@ public class CoreGuiceModuleTest extends AbstractModule {
         bind(OutingStore.class).toInstance(outingStore);
         bind(PathStore.class).toInstance(pathStore);
         bind(RecommendationService.class).toInstance(recommendationService);
-        bind(TokenService.class).to(TokenServiceJwt.class);
+        bind(TokenService.class).toInstance(tokenService);
         bind(OutingService.class).to(OutingServiceImpl.class);
     }
 

--- a/crCore/src/test/java/com/clueride/infrastructure/AuthenticationFilterTest.java
+++ b/crCore/src/test/java/com/clueride/infrastructure/AuthenticationFilterTest.java
@@ -1,0 +1,150 @@
+package com.clueride.infrastructure;/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 7/30/17.
+ */
+
+import javax.inject.Provider;
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+
+import com.google.inject.Inject;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Guice;
+import org.testng.annotations.Test;
+
+import com.clueride.CoreGuiceModuleTest;
+import com.clueride.service.TokenService;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Exercises the AuthenticationFilterTest class.
+ */
+@Guice(modules = CoreGuiceModuleTest.class)
+public class AuthenticationFilterTest {
+    private AuthenticationFilter toTest;
+    private static String ORIG_GUEST_TOKEN = "GuestToken";
+    private static String BAD_GUEST_TOKEN = "SomeoneElseGuestToken";
+    private static String NEW_GUEST_TOKEN = "NewGuestToken";
+
+    @Inject
+    private Provider<AuthenticationFilter> toTestProvider;
+
+    @Mock
+    private ContainerRequestContext requestContext;
+
+    @Inject
+    private TokenService tokenService;
+
+    @BeforeMethod
+    public void setUp() {
+        initMocks(this);
+        reset(
+                tokenService
+        );
+        toTest = toTestProvider.get();
+    }
+
+    @Test
+    public void testFilter_OK() throws Exception {
+        /* train mocks */
+        when(requestContext.getMethod()).thenReturn(HttpMethod.POST);
+        when(requestContext.getHeaderString(HttpHeaders.AUTHORIZATION))
+                .thenReturn("Bearer " + NEW_GUEST_TOKEN);
+
+        // Not expected for this scenario
+        ArgumentCaptor<Response> captor = ArgumentCaptor.forClass(Response.class);
+        doNothing().when(requestContext).abortWith(captor.capture());
+
+        /* make call */
+        toTest.filter(requestContext);
+
+        /* verify results */
+        verify(requestContext, times(0)).abortWith(any(Response.class));
+    }
+
+    @Test
+    public void testFilter_guest() throws Exception {
+        /* train mocks */
+        when(requestContext.getMethod()).thenReturn(HttpMethod.POST);
+        when(requestContext.getHeaderString(HttpHeaders.AUTHORIZATION))
+                .thenReturn("Bearer " + ORIG_GUEST_TOKEN);
+        when(tokenService.generateSignedToken()).thenReturn(NEW_GUEST_TOKEN);
+        ArgumentCaptor<Response> captor = ArgumentCaptor.forClass(Response.class);
+        doNothing().when(requestContext).abortWith(captor.capture());
+
+        /* make call */
+        toTest.filter(requestContext);
+
+        /* verify results */
+        Response capturedResponse = captor.getValue();
+        assertEquals(capturedResponse.getHeaderString(HttpHeaders.AUTHORIZATION), "Bearer " + NEW_GUEST_TOKEN);
+        verify(requestContext).abortWith(any(Response.class));
+        verify(tokenService, times(0)).validateToken(any(String.class));
+    }
+
+    @Test
+    public void testFilter_malformedToken() throws Exception {
+        /* train mocks */
+        when(requestContext.getMethod()).thenReturn(HttpMethod.POST);
+        when(requestContext.getHeaderString(HttpHeaders.AUTHORIZATION))
+                .thenReturn("missing required text" + ORIG_GUEST_TOKEN);
+        when(tokenService.generateSignedToken()).thenReturn(NEW_GUEST_TOKEN);
+        ArgumentCaptor<Response> captor = ArgumentCaptor.forClass(Response.class);
+        doNothing().when(requestContext).abortWith(captor.capture());
+
+        /* make call */
+        toTest.filter(requestContext);
+
+        /* verify results */
+        Response capturedResponse = captor.getValue();
+        assertEquals(capturedResponse.getStatusInfo(), Response.Status.UNAUTHORIZED);
+        verify(requestContext).abortWith(any(Response.class));
+
+    }
+
+    @Test
+    public void testFilter_invalidToken() throws Exception {
+        /* train mocks */
+        when(requestContext.getMethod()).thenReturn(HttpMethod.POST);
+        when(requestContext.getHeaderString(HttpHeaders.AUTHORIZATION))
+                .thenReturn("Bearer " + BAD_GUEST_TOKEN);
+        when(tokenService.generateSignedToken()).thenReturn(NEW_GUEST_TOKEN);
+        doThrow(new RuntimeException()).when(tokenService).validateToken(BAD_GUEST_TOKEN);
+        ArgumentCaptor<Response> captor = ArgumentCaptor.forClass(Response.class);
+        doNothing().when(requestContext).abortWith(captor.capture());
+
+        /* make call */
+        toTest.filter(requestContext);
+
+        /* verify results */
+        Response capturedResponse = captor.getValue();
+        assertEquals(capturedResponse.getStatusInfo(), Response.Status.UNAUTHORIZED);
+        verify(requestContext).abortWith(any(Response.class));
+    }
+
+}

--- a/crCore/src/test/java/com/clueride/service/TokenServiceJwtTest.java
+++ b/crCore/src/test/java/com/clueride/service/TokenServiceJwtTest.java
@@ -31,11 +31,11 @@ import static org.testng.Assert.assertEquals;
  */
 @Guice(modules=CoreGuiceModuleTest.class)
 public class TokenServiceJwtTest {
-    private TokenService toTest;
+    private TokenServiceJwt toTest;
     private String token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJjbHVlcmlkZS5jb20ifQ.i_K5QQC1lg2yeB-30wrMbm3dDIb7Az_WyCTxbg5wzr8";
 
     @Inject
-    private Provider<TokenService> toTestProvider;
+    private Provider<TokenServiceJwt> toTestProvider;
 
     @BeforeMethod
     public void setUp() throws Exception {


### PR DESCRIPTION
* Sets up response of new token when GuestToken is provided.
* Aborts request with UNAUTHORIZED if the token isn't what we like
* Passes through for OPTIONS requests for CORS.
* Improves the testability by injecting more of the functionality.
* Adds extra header for CORS to allow our customer header to be recognized.