### PR TITLE
CA-317 Move readiness-level logic out of Location instance and into t…

### DIFF
--- a/clueride/src/main/java/com/clueride/rest/LocationWebService.java
+++ b/clueride/src/main/java/com/clueride/rest/LocationWebService.java
@@ -50,12 +50,12 @@ import com.clueride.service.LocationService;
  */
 @Secured
 @Path("location")
-public class Location {
+public class LocationWebService {
     private final LocationService locationService;
     private final LocationTypeService locationTypeService;
 
     @Inject
-    public Location(
+    public LocationWebService(
             LocationService locationService,
             LocationTypeService locationTypeService
     ) {

--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -87,5 +87,11 @@
       <artifactId>guice</artifactId>
       <version>3.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>1.9.5</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/domain/src/main/java/com/clueride/domain/DomainGuiceModule.java
+++ b/domain/src/main/java/com/clueride/domain/DomainGuiceModule.java
@@ -21,6 +21,10 @@ import com.google.inject.AbstractModule;
 
 import com.clueride.domain.account.member.MemberStore;
 import com.clueride.domain.account.member.MemberStoreJpa;
+import com.clueride.domain.user.image.ImageService;
+import com.clueride.domain.user.image.ImageServiceImpl;
+import com.clueride.domain.user.image.ImageStore;
+import com.clueride.domain.user.image.ImageStoreJpa;
 import com.clueride.domain.user.latlon.LatLonService;
 import com.clueride.domain.user.latlon.LatLonServiceImpl;
 import com.clueride.domain.user.latlon.LatLonStore;
@@ -29,6 +33,8 @@ import com.clueride.domain.user.loctype.LocationTypeService;
 import com.clueride.domain.user.loctype.LocationTypeServiceImpl;
 import com.clueride.domain.user.loctype.LocationTypeStore;
 import com.clueride.domain.user.loctype.LocationTypeStoreJpa;
+import com.clueride.domain.user.place.ScoredLocationService;
+import com.clueride.domain.user.place.ScoredLocationServiceImpl;
 
 /**
  * Guice Bindings for the Domain module.
@@ -39,11 +45,14 @@ public class DomainGuiceModule extends AbstractModule {
         install(new DomainGuiceProviderModule());
 
         /* Bindings for Application use. */
+        bind(ImageService.class).to(ImageServiceImpl.class);
+        bind(ImageStore.class).to(ImageStoreJpa.class);
         bind(LatLonStore.class).to(LatLonStoreJpa.class);
         bind(LatLonService.class).to(LatLonServiceImpl.class);
         bind(LocationTypeService.class).to(LocationTypeServiceImpl.class);
         bind(LocationTypeStore.class).to(LocationTypeStoreJpa.class);
         bind(MemberStore.class).to(MemberStoreJpa.class);
+        bind(ScoredLocationService.class).to(ScoredLocationServiceImpl.class);
     }
 
 }

--- a/domain/src/main/java/com/clueride/domain/DomainGuiceProviderModule.java
+++ b/domain/src/main/java/com/clueride/domain/DomainGuiceProviderModule.java
@@ -26,6 +26,7 @@ import javax.persistence.EntityManager;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 
+import com.clueride.domain.user.image.Image;
 import com.clueride.domain.user.location.Location;
 import com.clueride.domain.user.loctype.LocationType;
 import com.clueride.infrastructure.JpaUtil;
@@ -84,5 +85,35 @@ public class DomainGuiceProviderModule extends AbstractModule {
                 .build();
     }
 
+    /**
+     * Image Builder appears similar to what comes out of the Store/DAO.
+     * @return partially constructed Image.Builder instance.
+     */
+    @Provides
+    private Image.Builder provideImageBuilder() {
+        String urlString = "https://images.clueride.com/img/4/1.jpg";
+        return Image.Builder.builder()
+                .withId(10)
+                .withUrlString(urlString);
+    }
+
+    /**
+     * Provides fully-constructed instance based on the provided imageBuilder.
+     * @param imageBuilder contains data similar to what comes out of DataStore.
+     * @return fully-constructed immutable instance.
+     */
+    @Provides
+    private Image provideImage(
+           Image.Builder imageBuilder
+    ) {
+        try {
+            return imageBuilder
+                    .withUrl(new URL(imageBuilder.getUrlString()))
+                    .build();
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
 
 }

--- a/domain/src/main/java/com/clueride/domain/user/ReadinessLevel.java
+++ b/domain/src/main/java/com/clueride/domain/user/ReadinessLevel.java
@@ -22,7 +22,7 @@ package com.clueride.domain.user;
  *
  * See http://bikehighways.wikidot.com/clueride-location-details for business definitions.
  */
-public enum LocationLevel {
+public enum ReadinessLevel {
     NODE,
     ISSUE,
     DRAFT,

--- a/domain/src/main/java/com/clueride/domain/user/image/Image.java
+++ b/domain/src/main/java/com/clueride/domain/user/image/Image.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 10/8/17.
+ */
+package com.clueride.domain.user.image;
+
+import java.net.URL;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Transient;
+
+import jdk.nashorn.internal.ir.annotations.Immutable;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+/**
+ * Details for recording the location of an Image to be used any place where it can be
+ * referenced by a URL.
+ *
+ * The Database stores just the String representation of the URL. The URL representation would added
+ * during the build of the instance.
+ */
+@Immutable
+public class Image {
+    private Integer id;
+    private URL url;
+
+    private Image(Builder builder) {
+        this.id = builder.getId();
+        this.url = builder.getUrl();
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public URL getUrl() {
+        return url;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return EqualsBuilder.reflectionEquals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    @Entity(name="image")
+    public static final class Builder implements com.clueride.domain.common.Builder<Image> {
+        @Id
+        @GeneratedValue(strategy= GenerationType.SEQUENCE, generator="image_pk_sequence")
+        @SequenceGenerator(name="image_pk_sequence",sequenceName="image_id_seq", allocationSize=1)
+        private Integer id;
+
+        @Column(name="url")
+        private String urlString;
+
+        @Transient
+        private URL url;
+
+        // TODO: CA-318 - Add builder() to the interface (as well as .from())
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public static Builder from(Image image) {
+            return new Builder()
+                    .withId(image.getId())
+                    .withUrl(image.getUrl())
+                    .withUrlString(image.getUrl().toString());
+        }
+
+        @Override
+        public Image build() {
+            return new Image(this);
+        }
+
+        public Integer getId() {
+            return id;
+        }
+
+        public Builder withId(Integer id) {
+            this.id = id;
+            return this;
+        }
+
+        public String getUrlString() {
+            return urlString;
+        }
+
+        public Builder withUrlString(String urlString) {
+            this.urlString = urlString;
+            return this;
+        }
+
+        public URL getUrl() {
+            return url;
+        }
+
+        public Builder withUrl(URL url) {
+            this.url = url;
+            return this;
+        }
+    }
+
+}

--- a/domain/src/main/java/com/clueride/domain/user/image/ImageService.java
+++ b/domain/src/main/java/com/clueride/domain/user/image/ImageService.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 10/8/17.
+ */
+package com.clueride.domain.user.image;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * Defines operations on Images.
+ */
+public interface ImageService {
+    /**
+     * Retrieves the Image instance matching the given ID.
+     * @param id unique identifier for the image.
+     * @return Fully-populated Image instance with valid URL.
+     */
+    Image getById(Integer id);
+
+    /**
+     * Given the ID of an image, retrieve the URL used to locate the image.
+     * @param id unique identifier for the image.
+     * @return Validated URL or null if there is no URL for the ID.
+     */
+    URL getImageUrl(Integer id);
+
+    /**
+     * Persists a new image.
+     * Validation of the URL occurs within this method.
+     * @param imageBuilder mutable object that contains at least the String representation for the image URL.
+     * @return New ID for the record.
+     */
+    Integer addNew(Image.Builder imageBuilder) throws MalformedURLException;
+
+}

--- a/domain/src/main/java/com/clueride/domain/user/image/ImageServiceImpl.java
+++ b/domain/src/main/java/com/clueride/domain/user/image/ImageServiceImpl.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 10/8/17.
+ */
+package com.clueride.domain.user.image;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import javax.inject.Inject;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+/**
+ * Implementation of ImageService interface.
+ */
+public class ImageServiceImpl implements ImageService {
+    private final ImageStore imageStore;
+
+    @Inject
+    public ImageServiceImpl(
+            ImageStore imageStore
+    ) {
+        this.imageStore = imageStore;
+    }
+
+    @Override
+    public Image getById(Integer id) {
+        Image.Builder imageBuilder = imageStore.getById(id);
+        if (imageBuilder == null) {
+            return null;
+        }
+        try {
+            imageBuilder.withUrl(new URL(imageBuilder.getUrlString()));
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+            throw new RuntimeException("Image from datastore has malformed URL", e);
+        }
+        return imageBuilder.build();
+    }
+
+    @Override
+    public URL getImageUrl(Integer id) {
+        if (id == null) {
+            return null;
+        }
+
+        Image image = getById(id);
+        if (image == null) {
+            return null;
+        }
+
+        return image.getUrl();
+    }
+
+    @Override
+    public Integer addNew(Image.Builder imageBuilder) throws MalformedURLException {
+        validateUrlString(imageBuilder.getUrlString());
+        imageBuilder
+                .withId(null)
+                .withUrl(new URL(imageBuilder.getUrlString()));
+        return imageStore.addNew(imageBuilder);
+    }
+
+    private void validateUrlString(String urlString) throws MalformedURLException {
+        if (isNullOrEmpty(urlString)) {
+            throw new RuntimeException("URL is null or empty");
+        }
+        new URL(urlString);
+    }
+}

--- a/domain/src/main/java/com/clueride/domain/user/image/ImageStore.java
+++ b/domain/src/main/java/com/clueride/domain/user/image/ImageStore.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 10/8/17.
+ */
+package com.clueride.domain.user.image;
+
+/**
+ * Defines how we persist images.
+ */
+public interface ImageStore {
+    /**
+     * Given a validated Image Builder, save as if it were a new record.
+     * @param imageBuilder Image metadata to be persisted.
+     * @return the ID of the record.
+     */
+    Integer addNew(Image.Builder imageBuilder);
+
+    /**
+     * Given an Image's ID, return the matching Image instance.
+     * @param imageId Unique identifier for the image.
+     * @return matching Image instance.
+     */
+    Image.Builder getById(Integer imageId);
+
+}

--- a/domain/src/main/java/com/clueride/domain/user/image/ImageStoreJpa.java
+++ b/domain/src/main/java/com/clueride/domain/user/image/ImageStoreJpa.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 10/8/17.
+ */
+package com.clueride.domain.user.image;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Implementation of the Image Store against JPA.
+ */
+public class ImageStoreJpa implements ImageStore {
+
+    private final EntityManager entityManager;
+
+    @Inject
+    public ImageStoreJpa(
+            @Nonnull EntityManager entityManager
+    ) {
+        this.entityManager = requireNonNull(entityManager, "missing Entity Manager");
+    }
+
+    @Override
+    public Integer addNew(Image.Builder imageBuilder) {
+        entityManager.getTransaction().begin();
+        entityManager.persist(imageBuilder);
+        entityManager.getTransaction().commit();
+        return imageBuilder.getId();
+    }
+
+    @Override
+    public Image.Builder getById(Integer imageId) {
+        if (imageId == null) {
+            return null;
+        }
+        entityManager.getTransaction().begin();
+        Image.Builder imageBuilder = entityManager.find(Image.Builder.class, imageId);
+        entityManager.getTransaction().commit();
+        return imageBuilder;
+    }
+}

--- a/domain/src/main/java/com/clueride/domain/user/image/README.md
+++ b/domain/src/main/java/com/clueride/domain/user/image/README.md
@@ -1,0 +1,21 @@
+Images are generally associated with Locations.
+
+Each location may have multiple images, but there 
+should be a single "Featured" image.
+
+Generally, there is a one-to-many relationship 
+between Locations and Images, but there can be 
+a single image that is associated with more than
+one location.  A typical example would be an
+image for a Location that is also shown to the 
+user when it best represents a Location Group --
+multiple locations close enough together they
+can be grouped on the map .
+
+There are two parts to the image:
+- The contents of the file.
+- The metadata for the image.
+
+The Contents are placed on a webserver that Apache can handle.
+
+The metadata (for this package) are persisted via JPA.

--- a/domain/src/main/java/com/clueride/domain/user/location/Location.java
+++ b/domain/src/main/java/com/clueride/domain/user/location/Location.java
@@ -39,12 +39,11 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import com.clueride.domain.Step;
-import com.clueride.domain.user.LocationLevel;
+import com.clueride.domain.user.ReadinessLevel;
 import com.clueride.domain.user.latlon.LatLon;
 import com.clueride.domain.user.loctype.LocationType;
 import com.clueride.service.IdProvider;
 import com.clueride.service.MemoryBasedLocationIdProvider;
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -62,6 +61,7 @@ public class Location implements Step {
     private final URL featuredImage;
     private final Integer googlePlaceId;
     private final LatLon latLon;
+    private final ReadinessLevel readinessLevel;
     private List<Integer> clueIds;
     private final List<URL> imageUrls;
     private final Integer locationGroupId;
@@ -78,6 +78,7 @@ public class Location implements Step {
         id = builder.getId();
         nodeId = builder.getNodeId();
         latLon = builder.getLatLon();
+        readinessLevel = builder.getReadinessLevel();
 
         // If any of these are missing, we're at the Draft level
         name = builder.getName();
@@ -200,37 +201,8 @@ public class Location implements Step {
      * Determines progress against criteria described here: http://bikehighways.wikidot.com/clueride-location-details
      * @return Readiness level based on completeness of the fields for this object.
      */
-    public LocationLevel getReadinessLevel() {
-        /* Emptiness across all of these makes it a NODE. */
-        if (isNullOrEmpty(name)
-                && isNullOrEmpty(description)
-                && featuredImage == null
-                && locationType.getId() == 0
-        ) {
-            return LocationLevel.NODE;
-        }
-
-        /* Handle anything that could make this a draft. */
-        if (isNullOrEmpty(name)
-                || isNullOrEmpty(description)
-                || featuredImage == null
-                || locationType.getId() == 0
-        ) {
-            return LocationLevel.DRAFT;
-        }
-
-        /* If we're missing the Clues, we're just a Place. */
-        if (clueIds.size() == 0) {
-            return LocationLevel.PLACE;
-        }
-
-        /* If everything else is defined except our Google Place ID, we're an Attraction. */
-        if (googlePlaceId == null) {
-            return LocationLevel.ATTRACTION;
-        } else {
-            return LocationLevel.FEATURED;
-        }
-
+    public ReadinessLevel getReadinessLevel() {
+        return readinessLevel;
     }
 
     public Integer getGooglePlaceId() {
@@ -317,6 +289,9 @@ public class Location implements Step {
         @Transient
         private String establishment;
 
+        @Transient
+        private ReadinessLevel readinessLevel;
+
         public Builder() {
             idProvider = new MemoryBasedLocationIdProvider();
         }
@@ -397,6 +372,11 @@ public class Location implements Step {
         public Builder withLocationType(LocationType locationType) {
             this.locationType = locationType;
             this.locationTypeId = locationType.getId();
+            return this;
+        }
+
+        public Builder withReadinessLevel(ReadinessLevel readinessLevel) {
+            this.readinessLevel = readinessLevel;
             return this;
         }
 
@@ -497,6 +477,15 @@ public class Location implements Step {
             return this;
         }
 
+        public Integer getFeaturedImageId() {
+            return featuredImageId;
+        }
+
+        public Builder withFeaturedImageId(int imageId) {
+            this.featuredImageId = imageId;
+            return this;
+        }
+
         public Integer getGooglePlaceId() {
             return googlePlaceId;
         }
@@ -518,6 +507,10 @@ public class Location implements Step {
                     .withImageUrls(location.imageUrls)
 //                    .withEstablishment(Optional.<Establishment>fromNullable(location.establishment))
             ;
+        }
+
+        public ReadinessLevel getReadinessLevel() {
+            return readinessLevel;
         }
     }
 

--- a/domain/src/main/java/com/clueride/domain/user/place/README.md
+++ b/domain/src/main/java/com/clueride/domain/user/place/README.md
@@ -1,0 +1,11 @@
+A Place is a ScoredLocation -- a Location that has been evaluated
+against multiple criteria based on the completeness of the data and 
+the value of the Location.
+
+The services performed in this package accept a Location carrying
+the basic information, and builds up a ScoredLocation by evaluating
+the basic information.
+
+The first evaluation moved into this package is the Readiness Level, 
+and other rankings are Tag scores, number of images. More detail on 
+this wiki page: http://bikehighways.wikidot.com/clueride-location-details

--- a/domain/src/main/java/com/clueride/domain/user/place/ScoredLocation.java
+++ b/domain/src/main/java/com/clueride/domain/user/place/ScoredLocation.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 10/8/17.
+ */
+package com.clueride.domain.user.place;
+
+/**
+ * TODO: Description.
+ */
+public class ScoredLocation {
+}

--- a/domain/src/main/java/com/clueride/domain/user/place/ScoredLocationService.java
+++ b/domain/src/main/java/com/clueride/domain/user/place/ScoredLocationService.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 10/8/17.
+ */
+package com.clueride.domain.user.place;
+
+import com.clueride.domain.user.ReadinessLevel;
+import com.clueride.domain.user.location.Location;
+
+/**
+ * Defines the operations for scoring a Location.
+ */
+public interface ScoredLocationService {
+    /**
+     * Given a Location, compute the Readiness level for that Location.
+     * @param location to be evaluated.
+     * @return Readiness Level
+     */
+    ReadinessLevel calculateReadinessLevel(Location.Builder location);
+}

--- a/domain/src/main/java/com/clueride/domain/user/place/ScoredLocationServiceImpl.java
+++ b/domain/src/main/java/com/clueride/domain/user/place/ScoredLocationServiceImpl.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 10/8/17.
+ */
+package com.clueride.domain.user.place;
+
+import com.clueride.domain.user.ReadinessLevel;
+import com.clueride.domain.user.location.Location;
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+/**
+ * Implementation of ScoredLocationService.
+ */
+public class ScoredLocationServiceImpl implements ScoredLocationService {
+
+    @Override
+    public ReadinessLevel calculateReadinessLevel(Location.Builder location) {
+                /* Emptiness across all of these makes it a NODE. */
+        if (isNullOrEmpty(location.getName())
+                && isNullOrEmpty(location.getDescription())
+                && location.getFeaturedImage() == null
+                && location.getLocationType().getId() == 0
+                ) {
+            return ReadinessLevel.NODE;
+        }
+
+        /* Handle anything that could make this a draft. */
+        if (isNullOrEmpty(location.getName())
+                || isNullOrEmpty(location.getDescription())
+                || location.getFeaturedImage() == null
+                || location.getLocationType().getId() == 0
+                ) {
+            return ReadinessLevel.DRAFT;
+        }
+
+        /* If we're missing the Clues, we're just a Place. */
+        if (location.getClueIds().size() == 0) {
+            return ReadinessLevel.PLACE;
+        }
+
+        /* If everything else is defined except our Google Place ID, we're an Attraction. */
+        if (location.getGooglePlaceId() == null) {
+            return ReadinessLevel.ATTRACTION;
+        } else {
+            return ReadinessLevel.FEATURED;
+        }
+    }
+
+}

--- a/domain/src/test/java/com/clueride/domain/DomainGuiceModuleTest.java
+++ b/domain/src/test/java/com/clueride/domain/DomainGuiceModuleTest.java
@@ -18,15 +18,31 @@
 package com.clueride.domain;
 
 import com.google.inject.AbstractModule;
+import org.mockito.Mock;
+
+import com.clueride.domain.user.image.ImageStore;
+import com.clueride.domain.user.image.ImageStoreJpa;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 /**
  * Guice Bindings for the Testing of the Domain Module.
  */
 public class DomainGuiceModuleTest extends AbstractModule {
+    private boolean runWithDB = ("true".equals(System.getProperty("db.available")));
+
+    @Mock
+    private ImageStore imageStore;
 
     @Override
     protected void configure() {
+        initMocks(this);
+
         install(new DomainGuiceProviderModule());
+        if (runWithDB) {
+            bind(ImageStore.class).to(ImageStoreJpa.class);
+        } else {
+            bind(ImageStore.class).toInstance(imageStore);
+        }
     }
 
 }

--- a/domain/src/test/java/com/clueride/domain/user/LocationTest.java
+++ b/domain/src/test/java/com/clueride/domain/user/LocationTest.java
@@ -18,7 +18,6 @@
 package com.clueride.domain.user;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import javax.inject.Provider;
@@ -42,9 +41,6 @@ public class LocationTest {
 
     @Inject
     private Provider<Location.Builder> toTestProvider;
-
-    @Inject
-    private Provider<LocationType> locationTypeProvider;
 
     // Test values
     private LocationType expectedLocationType;
@@ -81,138 +77,4 @@ public class LocationTest {
         builder.build();
     }
 
-    /* Readiness level. */
-
-    @Test
-    public void testReadinessLevel_Attraction() throws Exception {
-        LocationLevel expected = LocationLevel.ATTRACTION;
-        LocationLevel actual = toTest.getReadinessLevel();
-        assertEquals(actual, expected);
-    }
-
-    // Node's shouldn't be displayed
-    @Test
-    public void testReadinessLevel_Node() throws Exception {
-        /* setup test */
-        LocationLevel expected = LocationLevel.NODE;
-        LocationType locationTypeForNode = LocationType.Builder.from(locationTypeProvider.get())
-                .withId(0)
-                .build();
-        Location.Builder builder = Location.Builder.builder()
-                .withNodeId(toTest.getNodeId())
-                .withLatLon(toTest.getLatLon())
-                .withLocationType(locationTypeForNode);
-
-        toTest = builder.build();
-
-        /* make call */
-        LocationLevel actual = toTest.getReadinessLevel();
-
-        /* verify results */
-        assertEquals(actual, expected);
-    }
-
-    @Test
-    public void testReadinessLevel_Draft_onName() throws Exception {
-        LocationLevel expected = LocationLevel.DRAFT;
-        Location.Builder builder = Location.Builder.builder()
-                .withLocationType(toTest.getLocationType())
-                .withName(toTest.getName())
-                .withNodeId(toTest.getNodeId())
-                .withLatLon(toTest.getLatLon());
-
-        toTest = builder.build();
-        LocationLevel actual = toTest.getReadinessLevel();
-        assertEquals(actual, expected);
-    }
-
-    @Test
-    public void testReadinessLevel_Draft_onDescription() throws Exception {
-        LocationLevel expected = LocationLevel.DRAFT;
-        Location.Builder builder = Location.Builder.builder()
-                .withLocationType(toTest.getLocationType())
-                .withDescription(toTest.getDescription())
-                .withNodeId(toTest.getNodeId())
-                .withLatLon(toTest.getLatLon());
-
-        toTest = builder.build();
-        LocationLevel actual = toTest.getReadinessLevel();
-        assertEquals(actual, expected);
-    }
-
-    @Test
-    public void testReadinessLevel_Draft_onFeaturedImage() throws Exception {
-        LocationLevel expected = LocationLevel.DRAFT;
-        Location.Builder builder = Location.Builder.builder()
-                .withLocationType(toTest.getLocationType())
-                .withFeaturedImage(toTest.getFeaturedImage())
-                .withNodeId(toTest.getNodeId())
-                .withLatLon(toTest.getLatLon());
-
-        toTest = builder.build();
-        LocationLevel actual = toTest.getReadinessLevel();
-        assertEquals(actual, expected);
-    }
-
-    @Test
-    public void testReadinessLevel_Draft_onType() throws Exception {
-        LocationLevel expected = LocationLevel.DRAFT;
-        Location.Builder builder = Location.Builder.builder()
-                .withLocationType(toTest.getLocationType())
-                .withNodeId(toTest.getNodeId())
-                .withLatLon(toTest.getLatLon());
-
-        toTest = builder.build();
-        LocationLevel actual = toTest.getReadinessLevel();
-        assertEquals(actual, expected);
-    }
-
-    @Test
-    public void testReadinessLevel_Place_missingClues() throws Exception {
-        LocationLevel expected = LocationLevel.PLACE;
-
-        Location.Builder builder = Location.Builder.from(toTest);
-        builder.withClueIds(Collections.<Integer>emptyList());
-        toTest = builder.build();
-
-        LocationLevel actual = toTest.getReadinessLevel();
-        assertEquals(actual, expected);
-    }
-
-    @Test
-    public void testReadinessLevel_Featured() throws Exception {
-        LocationLevel expected = LocationLevel.FEATURED;
-
-        Location.Builder builder = Location.Builder.from(toTest);
-        builder.withGooglePlaceId(1);
-        toTest = builder.build();
-
-        LocationLevel actual = toTest.getReadinessLevel();
-        assertEquals(actual, expected);
-    }
-
-    @Test (expectedExceptions = NullPointerException.class)
-    public void testReadinessLevel_nullClues() throws Exception {
-        LocationLevel expected = LocationLevel.PLACE;
-
-        Location.Builder builder = Location.Builder.from(toTest);
-        builder.withClueIds(null);
-        toTest = builder.build();
-
-        LocationLevel actual = toTest.getReadinessLevel();
-        assertEquals(actual, expected);
-    }
-
-    @Test
-    public void testReadinessLevel_proposed() throws Exception {
-        LocationLevel expected = LocationLevel.DRAFT;
-
-        Location.Builder builder = Location.Builder.builder();
-        builder.withLatLon(toTest.getLatLon());
-        builder.withLocationType(toTest.getLocationType());
-        toTest = builder.build();
-
-        LocationLevel actual = toTest.getReadinessLevel();
-        assertEquals(actual, expected);
-    }
 }

--- a/domain/src/test/java/com/clueride/domain/user/image/ImageServiceImplTest.java
+++ b/domain/src/test/java/com/clueride/domain/user/image/ImageServiceImplTest.java
@@ -1,0 +1,149 @@
+package com.clueride.domain.user.image;/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 10/8/17.
+ */
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import org.testng.SkipException;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Guice;
+import org.testng.annotations.Test;
+
+import com.clueride.domain.DomainGuiceModuleTest;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Exercises the ImageServiceImplTest class.
+ */
+@Guice(modules= DomainGuiceModuleTest.class)
+public class ImageServiceImplTest {
+    private boolean runWithDB = ("true".equals(System.getProperty("db.available")));
+    private boolean runWithMocks = !runWithDB;
+
+    private ImageServiceImpl toTest;
+
+    @Inject
+    private Provider<ImageServiceImpl> toTestProvider;
+
+    @Inject
+    private Image image;
+
+    @Inject
+    private Image.Builder imageBuilder;
+
+    @Inject
+    private ImageStore imageStore;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        reportRunState();
+        assertNotNull(toTestProvider);
+        assertNotNull(image);
+
+        toTest = toTestProvider.get();
+        assertNotNull(toTest);
+    }
+
+    @Test
+    public void testGetById() throws Exception {
+    }
+
+    @Test
+    public void testAddNew() throws Exception {
+        validateDBAvailability();
+
+        toTest.addNew(Image.Builder.from(image));
+    }
+
+    @Test
+    public void testGetImageUrl_OK() throws Exception {
+        /* setup test */
+        URL expected = image.getUrl();
+        /* train mocks */
+        if (runWithMocks) {
+            when(imageStore.getById(image.getId())).thenReturn(imageBuilder);
+        }
+
+        /* make call */
+        URL actual = toTest.getImageUrl(image.getId());
+        assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testGetImageUrl_noImageForId() throws Exception {
+        /* train mocks */
+        if (runWithMocks) {
+            when(imageStore.getById(image.getId())).thenReturn(imageBuilder);
+        }
+
+        /* make call */
+        URL actual = toTest.getImageUrl(image.getId()+1);
+
+        assertTrue(actual == null);
+    }
+
+    @Test
+    public void testGetImageUrl_missingId() throws Exception {
+        /* train mocks */
+        if (runWithMocks) {
+            when(imageStore.getById(image.getId())).thenReturn(imageBuilder);
+        }
+
+        /* make call */
+        URL actual = toTest.getImageUrl(null);
+
+        assertTrue(actual == null);
+    }
+
+    private void validateDBAvailability() {
+        if (!runWithDB) {
+            throw new SkipException("Database isn't available");
+        }
+    }
+
+    @Test(expectedExceptions = RuntimeException.class)
+    public void testAddNew_emptyUrl() throws Exception {
+        /* setup test */
+        Image.Builder imageBuilderWithBadUrl = Image.Builder.builder().withUrlString("");
+        toTest.addNew(imageBuilderWithBadUrl);
+    }
+
+    @Test(expectedExceptions = MalformedURLException.class)
+    public void testAddNew_malformedUrl() throws Exception {
+        /* setup test */
+        Image.Builder imageBuilderWithBadUrl = Image.Builder.builder().withUrlString("htp://domain.org");
+        toTest.addNew(imageBuilderWithBadUrl);
+    }
+
+    private void reportRunState() {
+        if (runWithDB) {
+            System.out.println("Running with actual DB connection");
+        }
+
+        if (runWithMocks) {
+            System.out.println("Running with Mocked DAO/Stores");
+        }
+    }
+
+}

--- a/domain/src/test/java/com/clueride/domain/user/place/ScoredLocationServiceImplTest.java
+++ b/domain/src/test/java/com/clueride/domain/user/place/ScoredLocationServiceImplTest.java
@@ -1,0 +1,187 @@
+package com.clueride.domain.user.place;/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 10/8/17.
+ */
+
+import java.util.Collections;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Guice;
+import org.testng.annotations.Test;
+
+import com.clueride.domain.DomainGuiceModuleTest;
+import com.clueride.domain.user.ReadinessLevel;
+import com.clueride.domain.user.location.Location;
+import com.clueride.domain.user.loctype.LocationType;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Exercises the ScoredLocationServiceImplTest class.
+ */
+@Guice(modules= DomainGuiceModuleTest.class)
+public class ScoredLocationServiceImplTest {
+    private ScoredLocationServiceImpl toTest;
+
+    @Inject
+    private Location.Builder locationBuilder;
+
+    @Inject
+    private Provider<ScoredLocationServiceImpl> toTestProvider;
+
+    @Inject
+    private Provider<LocationType> locationTypeProvider;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        assertNotNull(toTestProvider);
+        assertNotNull(locationTypeProvider);
+
+        toTest = toTestProvider.get();
+        assertNotNull(toTest);
+    }
+
+    @Test
+    public void testCalculateReadinessLevel() throws Exception {
+    }
+
+    @Test
+    public void testReadinessLevel_Attraction() throws Exception {
+        ReadinessLevel expected = ReadinessLevel.ATTRACTION;
+        ReadinessLevel actual = toTest.calculateReadinessLevel(locationBuilder);
+        assertEquals(actual, expected);
+    }
+
+    // Node's shouldn't be displayed
+    @Test
+    public void testReadinessLevel_Node() throws Exception {
+        /* setup test */
+        ReadinessLevel expected = ReadinessLevel.NODE;
+        LocationType locationTypeForNode = LocationType.Builder.from(locationTypeProvider.get())
+                .withId(0)
+                .build();
+        Location.Builder builder = Location.Builder.builder()
+                .withNodeId(locationBuilder.getNodeId())
+                .withLatLon(locationBuilder.getLatLon())
+                .withLocationType(locationTypeForNode);
+
+        /* make call */
+        ReadinessLevel actual = toTest.calculateReadinessLevel(builder);
+
+        /* verify results */
+        assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testReadinessLevel_Draft_onName() throws Exception {
+        ReadinessLevel expected = ReadinessLevel.DRAFT;
+        Location.Builder builder = Location.Builder.builder()
+                .withLocationType(locationBuilder.getLocationType())
+                .withName(locationBuilder.getName())
+                .withNodeId(locationBuilder.getNodeId())
+                .withLatLon(locationBuilder.getLatLon());
+
+        ReadinessLevel actual = toTest.calculateReadinessLevel(builder);
+        assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testReadinessLevel_Draft_onDescription() throws Exception {
+        ReadinessLevel expected = ReadinessLevel.DRAFT;
+        Location.Builder builder = Location.Builder.builder()
+                .withLocationType(locationBuilder.getLocationType())
+                .withDescription(locationBuilder.getDescription())
+                .withNodeId(locationBuilder.getNodeId())
+                .withLatLon(locationBuilder.getLatLon());
+
+        ReadinessLevel actual = toTest.calculateReadinessLevel(builder);
+        assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testReadinessLevel_Draft_onFeaturedImage() throws Exception {
+        ReadinessLevel expected = ReadinessLevel.DRAFT;
+        Location.Builder builder = Location.Builder.builder()
+                .withLocationType(locationBuilder.getLocationType())
+                .withFeaturedImage(locationBuilder.getFeaturedImage())
+                .withNodeId(locationBuilder.getNodeId())
+                .withLatLon(locationBuilder.getLatLon());
+
+        ReadinessLevel actual = toTest.calculateReadinessLevel(builder);
+        assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testReadinessLevel_Draft_onType() throws Exception {
+        ReadinessLevel expected = ReadinessLevel.DRAFT;
+        Location.Builder builder = Location.Builder.builder()
+                .withLocationType(locationBuilder.getLocationType())
+                .withNodeId(locationBuilder.getNodeId())
+                .withLatLon(locationBuilder.getLatLon());
+
+        ReadinessLevel actual = toTest.calculateReadinessLevel(builder);
+        assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testReadinessLevel_Place_missingClues() throws Exception {
+        ReadinessLevel expected = ReadinessLevel.PLACE;
+
+        Location.Builder builder = Location.Builder.from(locationBuilder.build());
+        builder.withClueIds(Collections.<Integer>emptyList());
+
+        ReadinessLevel actual = toTest.calculateReadinessLevel(builder);
+        assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testReadinessLevel_Featured() throws Exception {
+        ReadinessLevel expected = ReadinessLevel.FEATURED;
+
+        Location.Builder builder = Location.Builder.from(locationBuilder.build());
+        builder.withGooglePlaceId(1);
+
+        ReadinessLevel actual = toTest.calculateReadinessLevel(builder);
+        assertEquals(actual, expected);
+    }
+
+    @Test (expectedExceptions = NullPointerException.class)
+    public void testReadinessLevel_nullClues() throws Exception {
+        ReadinessLevel expected = ReadinessLevel.PLACE;
+
+        Location.Builder builder = Location.Builder.from(locationBuilder.build());
+        builder.withClueIds(null);
+
+        ReadinessLevel actual = toTest.calculateReadinessLevel(builder);
+        assertEquals(actual, expected);
+    }
+
+    @Test
+    public void testReadinessLevel_proposed() throws Exception {
+        ReadinessLevel expected = ReadinessLevel.DRAFT;
+
+        Location.Builder builder = Location.Builder.builder();
+        builder.withLatLon(locationBuilder.getLatLon());
+        builder.withLocationType(locationBuilder.getLocationType());
+
+        ReadinessLevel actual = toTest.calculateReadinessLevel(builder);
+        assertEquals(actual, expected);
+    }
+
+}

--- a/service/src/main/java/com/clueride/dao/util/LocationImageUtilMain.java
+++ b/service/src/main/java/com/clueride/dao/util/LocationImageUtilMain.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 10/8/17.
+ */
+package com.clueride.dao.util;
+
+import java.net.URL;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+
+import com.clueride.domain.DomainGuiceModule;
+import com.clueride.domain.user.image.Image;
+import com.clueride.domain.user.image.ImageStore;
+import com.clueride.domain.user.location.Location;
+import com.clueride.domain.user.location.LocationStore;
+import com.clueride.infrastructure.Jpa;
+import com.clueride.infrastructure.Json;
+import com.clueride.infrastructure.ServiceGuiceModule;
+
+/**
+ * Helps move Images into database.
+ */
+public class LocationImageUtilMain {
+    private static LocationStore locationStoreJson;
+    private static LocationStore locationStoreJpa;
+    private static ImageStore imageStoreJpa;
+    private static Collection<Location> locations;
+
+    public static void main(String[] args) {
+        instantiateStores();
+        locations = locationStoreJson.getLocations();
+        System.out.println("Found  " + locations.size() + " locations");
+        for (Location location : locations) {
+            Location.Builder locationBuilder = Location.Builder.from(location);
+            URL firstUrl = location.getImageUrls().get(0);
+            int newImageId = persistImageUrl(firstUrl.toString());
+            locationBuilder.withFeaturedImageId(newImageId);
+        }
+    }
+
+    private static int persistImageUrl(String urlString) {
+        Image.Builder imageBuilder = Image.Builder.builder().withUrlString(urlString);
+        return imageStoreJpa.addNew(imageBuilder);
+    }
+
+    /**
+     * Used to check the uniqueness of the inbound data.
+     * @param locations
+     * @return
+     */
+    private static Map<String,Integer> buildImageMap(Collection<Location> locations) {
+        Map<String,Integer> urlStringToLocationId = new HashMap<>();
+        int totalCount = 0;
+        for (Location location : locations) {
+            int locationId = location.getId();
+            int imageCountForThisLocation = location.getImageUrls().size();
+            totalCount += imageCountForThisLocation;
+            System.out.println("Location ID " + locationId + " has " + imageCountForThisLocation + " images");
+            for (URL imageUrl : location.getImageUrls()) {
+              urlStringToLocationId.put(imageUrl.toString(), locationId);
+              System.out.println(imageUrl.toString() + ": " + locationId);
+            }
+        }
+        System.out.println("Images Total: " + totalCount);
+        System.out.println("Unique Images: " + urlStringToLocationId.values().size());
+        return urlStringToLocationId;
+    }
+
+    private static void instantiateStores() {
+        Injector injector = Guice.createInjector(
+                new DomainGuiceModule(),
+                new ServiceGuiceModule()
+        );
+
+        locationStoreJson = injector.getInstance(
+                Key.get(
+                        LocationStore.class,
+                        Json.class
+                )
+        );
+
+        locationStoreJpa = injector.getInstance(
+                Key.get(
+                        LocationStore.class,
+                        Jpa.class
+                )
+        );
+
+        imageStoreJpa = injector.getInstance(
+                ImageStore.class
+        );
+
+        if (
+                locationStoreJpa == null ||
+                locationStoreJson == null ||
+                imageStoreJpa == null
+        ) {
+            throw new RuntimeException("Unable to instantiate services");
+        }
+    }
+}


### PR DESCRIPTION
…he Service

* Adds ScoredLocationService as new home for Readiness level and other
evaluations to come.
* Introduces mechanism for switching tests and implementations of Datastore
depending on configuration value (CA-316).
* Adds support for new Image table.
* Addresses missing parts of the Readiness Evaluation (missing the Featured Image URL).
* Renames the REST Location to use 'WebService' as part of the name.