### PR TITLE
CA-326 Prepare back-end to accept Images linked to the Location

### DIFF
--- a/clueride/src/main/java/com/clueride/rest/LocationWebService.java
+++ b/clueride/src/main/java/com/clueride/rest/LocationWebService.java
@@ -110,9 +110,9 @@ public class LocationWebService {
     @Produces(MediaType.TEXT_PLAIN)
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     public String uploadImage(
-            @QueryParam("lat") Double lat,
-            @QueryParam("lon") Double lon,
-            @QueryParam("locId") Integer locationId,
+            @FormDataParam("lat") Double lat,
+            @FormDataParam("lon") Double lon,
+            @FormDataParam("locId") Integer locationId,
             @FormDataParam("file") InputStream fileData
     ) {
         locationService.saveLocationImage(

--- a/crCore/src/main/java/com/clueride/principal/PrincipalServiceImpl.java
+++ b/crCore/src/main/java/com/clueride/principal/PrincipalServiceImpl.java
@@ -61,12 +61,13 @@ public class PrincipalServiceImpl implements PrincipalService {
             memberService.getMemberByEmail(email);
             principals.add(principal);
         }  catch (Exception e) {
+            LOGGER.warn("Problem validating email", e);
             throw new InvalidClaimException("Unable to verify email: " + email);
         }
     }
 
     private void refreshPrincipalCache() {
-        if (principals == null) {
+        if (principals == null || principals.size() == 0) {
             principals = new ArrayList<>();
             getCount();
         }

--- a/crCore/src/main/java/com/clueride/service/LocationService.java
+++ b/crCore/src/main/java/com/clueride/service/LocationService.java
@@ -50,7 +50,7 @@ public interface LocationService {
      * @param locationId - Optional Integer representing an existing location (which may not have been created yet).
      * @param fileData - InputStream from which we read the image data to put into a file.
      */
-    void saveLocationImage(Double lat, Double lon, Integer locationId, InputStream fileData);
+    Integer saveLocationImage(Double lat, Double lon, Integer locationId, InputStream fileData);
 
     /**
      * Given the device's location -- or any relevant lat/lon pair -- return a list

--- a/crCore/src/test/java/com/clueride/service/DefaultLocationServiceTest.java
+++ b/crCore/src/test/java/com/clueride/service/DefaultLocationServiceTest.java
@@ -52,7 +52,7 @@ import static org.testng.AssertJUnit.assertTrue;
 @Guice(modules=CoreGuiceModuleTest.class)
 public class DefaultLocationServiceTest {
     private static final Logger LOGGER = Logger.getLogger(DefaultLocationServiceTest.class);
-    private LocationService toTest;
+    private DefaultLocationService toTest;
 
     @Inject
     private Location location;
@@ -173,4 +173,12 @@ public class DefaultLocationServiceTest {
         assertEquals(actual, expected);
     }
 
+    @Test
+    public void testDecodeBase64() {
+//        String expected = "Test String to be encoded";
+//
+//        String encoded = "data:image/jpeg;base64," + BaseEncoding.base64().encode(expected);
+//        String actual = toTest.decodeBase64(encoded);
+//        assertEquals(actual, expected);
+    }
 }

--- a/domain/src/main/java/com/clueride/domain/user/image/ImageService.java
+++ b/domain/src/main/java/com/clueride/domain/user/image/ImageService.java
@@ -19,6 +19,7 @@ package com.clueride.domain.user.image;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.List;
 
 /**
  * Defines operations on Images.
@@ -46,4 +47,23 @@ public interface ImageService {
      */
     Integer addNew(Image.Builder imageBuilder) throws MalformedURLException;
 
+    /**
+     * Persists a new image for a given Location.
+     * Validation of the location assures it has been created.
+     * @param imageBuilder mutable object containing at least the String representation for the image URL.
+     * @param locationId unique identifier for the Location this image represents.
+     * @return New ID for the record.
+     * @throws MalformedURLException if the supplied URL has problems.
+     */
+    Integer addNewToLocation(
+            Image.Builder imageBuilder,
+            Integer locationId
+    ) throws MalformedURLException;
+
+    /**
+     * Given a Location ID, retrieve the list of Images for that location.
+     * @param locationId unique identifier for the location.
+     * @return List<Image> matching the location.
+     */
+    List<Image> getImagesByLocation(Integer locationId);
 }

--- a/domain/src/main/java/com/clueride/domain/user/image/ImageServiceImpl.java
+++ b/domain/src/main/java/com/clueride/domain/user/image/ImageServiceImpl.java
@@ -19,10 +19,12 @@ package com.clueride.domain.user.image;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.List;
 
 import javax.inject.Inject;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Implementation of ImageService interface.
@@ -73,6 +75,26 @@ public class ImageServiceImpl implements ImageService {
                 .withId(null)
                 .withUrl(new URL(imageBuilder.getUrlString()));
         return imageStore.addNew(imageBuilder);
+    }
+
+    @Override
+    public Integer addNewToLocation(
+            Image.Builder imageBuilder,
+            Integer locationId
+    ) throws MalformedURLException {
+        validateLocationId(locationId);
+        Integer newImageId = addNew(imageBuilder);
+        Integer mapId = imageStore.linkImageToLocation(newImageId, locationId);
+        return newImageId;
+    }
+
+    private void validateLocationId(Integer locationId) {
+        requireNonNull(locationId);
+    }
+
+    @Override
+    public List<Image> getImagesByLocation(Integer locationId) {
+        return null;
     }
 
     private void validateUrlString(String urlString) throws MalformedURLException {

--- a/domain/src/main/java/com/clueride/domain/user/image/ImageStore.java
+++ b/domain/src/main/java/com/clueride/domain/user/image/ImageStore.java
@@ -35,4 +35,13 @@ public interface ImageStore {
      */
     Image.Builder getById(Integer imageId);
 
+    /**
+     * Given the ID of both a persisted image and a persisted Location, record a link
+     * between the two.
+     * @param imageId unique identifier for an Image.
+     * @param locationId unique identifier for a Location.
+     * @return ID of the record linking the Image and the Location.
+     */
+    Integer linkImageToLocation(Integer imageId, Integer locationId);
+
 }

--- a/domain/src/main/java/com/clueride/domain/user/image/ImageStoreJpa.java
+++ b/domain/src/main/java/com/clueride/domain/user/image/ImageStoreJpa.java
@@ -19,7 +19,12 @@ package com.clueride.domain.user.image;
 
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
+import javax.persistence.Entity;
 import javax.persistence.EntityManager;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
 
 import static java.util.Objects.requireNonNull;
 
@@ -54,5 +59,30 @@ public class ImageStoreJpa implements ImageStore {
         Image.Builder imageBuilder = entityManager.find(Image.Builder.class, imageId);
         entityManager.getTransaction().commit();
         return imageBuilder;
+    }
+
+    @Override
+    public Integer linkImageToLocation(Integer imageId, Integer locationId) {
+        ImageByLocation imageByLocation = new ImageByLocation();
+        imageByLocation.image_id = imageId;
+        imageByLocation.location_id = locationId;
+
+        entityManager.getTransaction().begin();
+        entityManager.persist(imageByLocation);
+        entityManager.getTransaction().commit();
+        return imageByLocation.id;
+    }
+
+    @Entity(name="image_by_location")
+    public static class ImageByLocation {
+        @Id
+        @GeneratedValue(strategy= GenerationType.SEQUENCE, generator="image_by_location_pk_sequence")
+        @SequenceGenerator(name="image_by_location_pk_sequence",
+                sequenceName="images_by_location_id_seq",
+                allocationSize=1)
+        Integer id;
+
+        Integer image_id;
+        Integer location_id;
     }
 }


### PR DESCRIPTION
* Adds new JPA entity for the map between Location and Images.
* Adds debugging to help sort out why I couldn't validate a valid email.
* Expands API for Location Service and Image Service.

This breaks the old API: now using FormDataParam for all elements of the
upload Image request.

Second commit to handle streams that are sent as Base64 encoding.