### PR TITLE
CA-329 Provide API for retrieving a single Location (via JPA)

### DIFF
--- a/clueride/src/main/java/com/clueride/rest/LocationWebService.java
+++ b/clueride/src/main/java/com/clueride/rest/LocationWebService.java
@@ -31,6 +31,7 @@ import javax.ws.rs.core.MediaType;
 
 import org.glassfish.jersey.media.multipart.FormDataParam;
 
+import com.clueride.domain.user.image.Image;
 import com.clueride.domain.user.latlon.LatLon;
 import com.clueride.domain.user.loctype.LocationType;
 import com.clueride.domain.user.loctype.LocationTypeService;
@@ -103,23 +104,22 @@ public class LocationWebService {
      * @param lon - Double longitude of device location.
      * @param locationId - Optional Integer representing an existing location (which may not have been created yet).
      * @param fileData - InputStream from which we read the image data to put into a file.
-     * @return "OK" confirming success.
+     * @return Image instance which has just been created.
      */
     @POST
     @Path("uploadImage")
     @Produces(MediaType.TEXT_PLAIN)
     @Consumes(MediaType.MULTIPART_FORM_DATA)
-    public String uploadImage(
+    public Image uploadImage(
             @FormDataParam("lat") Double lat,
             @FormDataParam("lon") Double lon,
             @FormDataParam("locId") Integer locationId,
             @FormDataParam("file") InputStream fileData
     ) {
-        locationService.saveLocationImage(
+        return locationService.saveLocationImage(
                 lat, lon,
                 locationId,
                 fileData);
-        return "OK";
     }
 
     /**

--- a/crCore/src/main/java/com/clueride/service/LocationService.java
+++ b/crCore/src/main/java/com/clueride/service/LocationService.java
@@ -19,6 +19,7 @@ package com.clueride.service;
 
 import java.io.InputStream;
 
+import com.clueride.domain.user.image.Image;
 import com.clueride.domain.user.latlon.LatLon;
 import com.clueride.domain.user.location.Location;
 
@@ -58,7 +59,7 @@ public interface LocationService {
      * @param locationId - Optional Integer representing an existing location (which may not have been created yet).
      * @param fileData - InputStream from which we read the image data to put into a file.
      */
-    Integer saveLocationImage(Double lat, Double lon, Integer locationId, InputStream fileData);
+    Image saveLocationImage(Double lat, Double lon, Integer locationId, InputStream fileData);
 
     /**
      * Given the device's location -- or any relevant lat/lon pair -- return a list


### PR DESCRIPTION
* Adds get location method returning a Location by ID.
* Deprecates get location method returning a string.
* Switches web service to use new method.
* refactors fill and grade functionality to separate method.
* Now returns Image instance as JSON instead of text.

Population of the object was verified by Postman rather than unit test
against 4 services.