### PR TITLE
CA-340 Provide service that accepts the BadgeEvent

### DIFF
--- a/crCore/src/test/java/com/clueride/CoreGuiceModuleTest.java
+++ b/crCore/src/test/java/com/clueride/CoreGuiceModuleTest.java
@@ -18,7 +18,6 @@
 package com.clueride;
 
 import java.security.Principal;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -48,14 +47,12 @@ import com.clueride.domain.GeoNode;
 import com.clueride.domain.Outing;
 import com.clueride.domain.account.member.Member;
 import com.clueride.domain.account.member.MemberService;
-import com.clueride.domain.account.member.MemberStore;
 import com.clueride.domain.account.principal.EmailPrincipal;
 import com.clueride.domain.account.principal.PrincipalService;
 import com.clueride.domain.dev.NetworkProposal;
 import com.clueride.domain.dev.NewNodeProposal;
 import com.clueride.domain.dev.TrackImpl;
 import com.clueride.domain.factory.PointFactory;
-import com.clueride.domain.user.Badge;
 import com.clueride.domain.user.image.ImageService;
 import com.clueride.domain.user.latlon.LatLonService;
 import com.clueride.domain.user.latlon.LatLonStore;
@@ -124,9 +121,6 @@ public class CoreGuiceModuleTest extends AbstractModule {
     private MemberService memberService;
 
     @Mock
-    private MemberStore memberStore;
-
-    @Mock
     private NodeStore nodeStore;
 
     @Mock
@@ -176,7 +170,6 @@ public class CoreGuiceModuleTest extends AbstractModule {
         bind(LocationTypeService.class).toInstance(locationTypeService);
         bind(LocationService.class).toInstance(locationService);
         bind(MemberService.class).toInstance(memberService);
-        bind(MemberStore.class).toInstance(memberStore);
         bind(NodeService.class).toInstance(nodeService);
         bind(NodeStore.class).toInstance(nodeStore);
         bind(OutingService.class).to(OutingServiceImpl.class);
@@ -268,18 +261,6 @@ public class CoreGuiceModuleTest extends AbstractModule {
                 .withHeader(headerClaims)
                 .withJWTId(jtiService.registerNewId())
                 .withExpiresAt(inASecond);
-    }
-
-    @Provides
-    private Member getMember() {
-        return Member.Builder.builder()
-                .withFirstName("ClueRide")
-                .withLastName("Guest")
-                .withEmailAddress("guest.dummy@clueride.com")
-                .withBadges(Collections.singletonList(Badge.LOCATION_EDITOR))
-                .withDisplayName("ClueRide Guest")
-                .withPhone("123-456-7890")
-                .build();
     }
 
     @Provides NetworkProposal getNewNodeNetworkProposal(GeoNode geoNode) {

--- a/domain/src/main/java/com/clueride/domain/DomainGuiceModule.java
+++ b/domain/src/main/java/com/clueride/domain/DomainGuiceModule.java
@@ -27,6 +27,8 @@ import com.clueride.domain.account.principal.SessionPrincipal;
 import com.clueride.domain.account.principal.SessionPrincipalImpl;
 import com.clueride.domain.badge.event.BadgeEventService;
 import com.clueride.domain.badge.event.BadgeEventServiceImpl;
+import com.clueride.domain.badge.event.BadgeEventStore;
+import com.clueride.domain.badge.event.BadgeEventStoreJpa;
 import com.clueride.domain.user.image.ImageService;
 import com.clueride.domain.user.image.ImageServiceImpl;
 import com.clueride.domain.user.image.ImageStore;
@@ -56,6 +58,7 @@ public class DomainGuiceModule extends AbstractModule {
 
         /* Bindings for Application use. */
         bind(BadgeEventService.class).to(BadgeEventServiceImpl.class);
+        bind(BadgeEventStore.class).to(BadgeEventStoreJpa.class);
         bind(ImageService.class).to(ImageServiceImpl.class);
         bind(ImageStore.class).to(ImageStoreJpa.class);
         bind(LatLonStore.class).to(LatLonStoreJpa.class);

--- a/domain/src/main/java/com/clueride/domain/badge/event/BadgeEvent.java
+++ b/domain/src/main/java/com/clueride/domain/badge/event/BadgeEvent.java
@@ -20,6 +20,15 @@ package com.clueride.domain.badge.event;
 import java.security.Principal;
 import java.util.Date;
 
+import javax.annotation.concurrent.Immutable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Transient;
+
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -27,19 +36,28 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 /**
  * DTO for the data captured for Badge-worthy deeds.
  */
+@Immutable
 public class BadgeEvent {
+    private Integer id;
     private Date timestamp;
     private Principal principal;
+    private Integer memberId;
     private String methodName;
     private Class methodClass;
     private Object returnValue;
 
     private BadgeEvent(Builder builder) {
+        this.id = builder.id;
         this.timestamp = builder.timestamp;
         this.principal = builder.principal;
+        this.memberId = builder.memberId;
         this.methodClass = builder.methodClass;
         this.methodName = builder.methodName;
         this.returnValue = builder.returnValue;
+    }
+
+    public Integer getId() {
+        return id;
     }
 
     public Date getTimestamp() {
@@ -48,6 +66,10 @@ public class BadgeEvent {
 
     public Principal getPrincipal() {
         return principal;
+    }
+
+    public Integer getMemberId() {
+        return memberId;
     }
 
     public String getMethodName() {
@@ -80,11 +102,35 @@ public class BadgeEvent {
     /**
      * Mutable instance of BadgeEvent.
      */
+    @Entity(name="badge_event")
     public static class Builder {
+        @Id
+        @GeneratedValue(strategy= GenerationType.SEQUENCE, generator = "badge_event_pk_sequence")
+        @SequenceGenerator(name="badge_event_pk_sequence", sequenceName = "badge_event_id_seq", allocationSize = 1)
+        private Integer id;
+
+        @Column
         private Date timestamp;
+
+        @Transient
         private Principal principal;
+
+        @Column(name="member_id")
+        private Integer memberId;
+
+        @Column(name="method_name")
         private String methodName;
+
+        @Column(name="class_name")
+        private String className;
+
+        @Transient
         private Class methodClass;
+
+        @Column(name="return_value")
+        private String returnValueAsString;
+
+        @Transient
         private Object returnValue;
 
         public BadgeEvent build() {
@@ -97,11 +143,25 @@ public class BadgeEvent {
 
         public static Builder from(BadgeEvent badgeEvent) {
             return builder()
+                    .withId(badgeEvent.id)
                     .withPrincipal(badgeEvent.principal)
+                    .withMemberId(badgeEvent.memberId)
                     .withTimestamp(badgeEvent.timestamp)
                     .withMethodClass(badgeEvent.methodClass)
+                    .withClassName(badgeEvent.methodClass.getCanonicalName())
                     .withMethodName(badgeEvent.methodName)
-                    .withReturnValue(badgeEvent.returnValue);
+                    .withReturnValue(badgeEvent.returnValue)
+                    .withReturnValueAsString(badgeEvent.returnValue.toString())
+                    ;
+        }
+
+        public Integer getId() {
+            return id;
+        }
+
+        public Builder withId(Integer id) {
+            this.id = id;
+            return this;
         }
 
         public Date getTimestamp() {
@@ -110,6 +170,15 @@ public class BadgeEvent {
 
         public Builder withTimestamp(Date timestamp) {
             this.timestamp = timestamp;
+            return this;
+        }
+
+        public Integer getMemberId() {
+            return memberId;
+        }
+
+        public Builder withMemberId(Integer memberId) {
+            this.memberId = memberId;
             return this;
         }
 
@@ -131,12 +200,22 @@ public class BadgeEvent {
             return this;
         }
 
+        public Builder withClassName(String className) {
+            this.className = className;
+            return this;
+        }
+
+        public String getClassName() {
+            return className;
+        }
+
         public Class getMethodClass() {
             return methodClass;
         }
 
         public Builder withMethodClass(Class methodClass) {
             this.methodClass = methodClass;
+            this.className = methodClass.getCanonicalName();
             return this;
         }
 
@@ -146,7 +225,17 @@ public class BadgeEvent {
 
         public Builder withReturnValue(Object returnValue) {
             this.returnValue = returnValue;
+            this.returnValueAsString = returnValue.toString();
             return this;
+        }
+
+        private Builder withReturnValueAsString(String returnValueAsString) {
+            this.returnValueAsString = returnValueAsString;
+            return this;
+        }
+
+        public String getReturnValueAsString() {
+            return returnValueAsString;
         }
 
         @Override

--- a/domain/src/main/java/com/clueride/domain/badge/event/BadgeEventServiceImpl.java
+++ b/domain/src/main/java/com/clueride/domain/badge/event/BadgeEventServiceImpl.java
@@ -17,12 +17,112 @@
  */
 package com.clueride.domain.badge.event;
 
+import java.security.Principal;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedTransferQueue;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.apache.log4j.Logger;
+
+import com.clueride.domain.account.member.Member;
+import com.clueride.domain.account.member.MemberService;
+import com.clueride.domain.account.principal.PrincipalService;
+
 /**
- * TODO: CA-340
+ * Implementation of Badge Event service which dispatches events from a queue that is populated by clients.
+ *
+ * The dispatch involves persisting and logging of the events.
  */
+@Singleton
 public class BadgeEventServiceImpl implements BadgeEventService {
-    @Override
-    public void send(BadgeEvent.Builder badgeEvent) {
+    private static final Logger LOGGER = Logger.getLogger(BadgeEventServiceImpl.class);
+    private static BlockingQueue<BadgeEvent.Builder> eventQueue = new LinkedTransferQueue<>();
+    private static Thread workerThread = null;
+    private boolean runnable = true;
+    private final BadgeEventStore badgeEventStore;
+    private final MemberService memberService;
+    private final PrincipalService principalService;
+
+    @Inject
+    public BadgeEventServiceImpl(
+            BadgeEventStore badgeEventStore,
+            MemberService memberService,
+            PrincipalService principalService
+    ) {
+        this.badgeEventStore = badgeEventStore;
+        this.memberService = memberService;
+        this.principalService = principalService;
+
+        if (workerThread == null) {
+            workerThread = new Thread(
+                    new BadgeEventServiceImpl.Worker()
+            );
+            workerThread.start();
+        }
 
     }
+
+    @Override
+    public void send(BadgeEvent.Builder badgeEvent) {
+        try {
+            synchronized(eventQueue) {
+                eventQueue.put(badgeEvent);
+            }
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public BadgeEvent getBadgeEventById(Integer badgeEventId) {
+        BadgeEvent.Builder badgeEventBuilder = badgeEventStore.getById(badgeEventId);
+        fillDbBuilder(badgeEventBuilder);
+        return badgeEventBuilder.build();
+    }
+
+    private void fillDbBuilder(BadgeEvent.Builder badgeEventBuilder) {
+        Member member = memberService.getMember(badgeEventBuilder.getMemberId());
+        badgeEventBuilder.withPrincipal(
+                principalService.getPrincipalForEmailAddress(
+                        member.getEmailAddress()
+                )
+        );
+    }
+
+    private void fillClientBuilder(BadgeEvent.Builder badgeEventBuilder) {
+        Principal principal = badgeEventBuilder.getPrincipal();
+        Integer memberId = memberService.getMemberByEmail(
+                principal.getName()
+        ).getId();
+
+        badgeEventBuilder.withMemberId(memberId);
+    }
+
+    public class Worker implements Runnable {
+
+        @Override
+        public void run() {
+            while (runnable) {
+                BadgeEvent.Builder badgeEventBuilder = null;
+                try {
+                    badgeEventBuilder = eventQueue.take();
+                    fillClientBuilder(badgeEventBuilder);
+                    LOGGER.info("Captured Event: " + badgeEventBuilder.toString());
+                    badgeEventStore.add(badgeEventBuilder);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                    runnable = false;
+                } catch (RuntimeException rte) {
+                    LOGGER.error("Problem Storing Badge Event: " + badgeEventBuilder.getTimestamp(), rte);
+                    throw(rte);
+                }
+
+            }
+        }
+
+    }
+
+
 }

--- a/domain/src/main/java/com/clueride/domain/badge/event/BadgeEventStore.java
+++ b/domain/src/main/java/com/clueride/domain/badge/event/BadgeEventStore.java
@@ -18,20 +18,21 @@
 package com.clueride.domain.badge.event;
 
 /**
- * Operations on Badge Events.
+ * Persistence operations for Badge Events.
  */
-public interface BadgeEventService {
+public interface BadgeEventStore {
     /**
-     * Passes captured Badge Event to the service thread that persists the event.
-     * @param badgeEvent instance of captured Badge Event.
+     * Create a new instance of Badge Event from the Builder.
+     * @param badgeEventBuilder instance of Builder for the BadgeEvent.
+     * @return Unique ID of the newly created record.
      */
-    void send(BadgeEvent.Builder badgeEvent);
+    Integer add(BadgeEvent.Builder badgeEventBuilder);
 
     /**
-     * Given the unique identifier for a Badge Event, retrieve that badge event.
+     * Return the matching BadgeEvent (as a Builder) given the ID.
      * @param badgeEventId unique identifier for the Badge Event.
-     * @return fully-populated Badge Event.
+     * @return partially populated BadgeEvent; needs other services to fill remaining fields.
      */
-    BadgeEvent getBadgeEventById(Integer badgeEventId);
+    BadgeEvent.Builder getById(Integer badgeEventId);
 
 }

--- a/domain/src/main/java/com/clueride/domain/badge/event/README.md
+++ b/domain/src/main/java/com/clueride/domain/badge/event/README.md
@@ -1,0 +1,24 @@
+Three fields from the BadgeEvent are stored in the database in fields that 
+ - require expansion once brought into memory
+ - require conversion to store
+The service layer is responsible for mapping across these instances.
+ 
+Inbound during capture:
+- Principal is stored as Member ID
+- Class is presented as String
+- Return Value is stored as String
+
+Outbound when retrieving:
+- Principal is looked up from Member ID
+- Class is looked up from ClassName (maybe)
+- Return Value is presented as String
+
+Only Principal lookup is implemented in both directions at this time 
+(until we feel there is an actual use of the Class rather than just the name)
+
+Considered: Return Value is stored as string, but it may be
+worthwhile turning into something else.
+
+The annotation @DbSourced is used for test instances that hold the persisted fields.
+The annotation @ServiceSourced is used for fully-populated instances.
+The annotation @ClientSourced is used for inbound capture instances.

--- a/domain/src/main/java/com/clueride/infrastructure/ClientSourced.java
+++ b/domain/src/main/java/com/clueride/infrastructure/ClientSourced.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 11/26/17.
+ */
+package com.clueride.infrastructure;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import com.google.inject.BindingAnnotation;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotation indicating a populated Builder should appear
+ * the way it comes out of the database instead of a fully-populated
+ * instance that comes out of a service.
+ */
+@BindingAnnotation
+@Retention(RUNTIME)
+@Target({TYPE, METHOD, PARAMETER, FIELD})
+public @interface ClientSourced {
+}

--- a/domain/src/main/java/com/clueride/infrastructure/DbSourced.java
+++ b/domain/src/main/java/com/clueride/infrastructure/DbSourced.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 11/26/17.
+ */
+package com.clueride.infrastructure;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import com.google.inject.BindingAnnotation;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotation indicating a populated Builder should appear
+ * the way it comes out of the database instead of a fully-populated
+ * instance that comes out of a service.
+ */
+@BindingAnnotation
+@Retention(RUNTIME)
+@Target({TYPE, METHOD, PARAMETER, FIELD})
+public @interface DbSourced {
+}

--- a/domain/src/main/java/com/clueride/infrastructure/ServiceSourced.java
+++ b/domain/src/main/java/com/clueride/infrastructure/ServiceSourced.java
@@ -1,0 +1,34 @@
+package com.clueride.infrastructure;/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 11/26/17.
+ */
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import com.google.inject.BindingAnnotation;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@BindingAnnotation
+@Retention(RUNTIME)
+@Target({TYPE, METHOD, PARAMETER, FIELD})
+public @interface ServiceSourced {
+}

--- a/domain/src/test/java/com/clueride/domain/DomainGuiceModuleTest.java
+++ b/domain/src/test/java/com/clueride/domain/DomainGuiceModuleTest.java
@@ -26,10 +26,12 @@ import org.mockito.Mock;
 import com.clueride.aop.AopDummyService;
 import com.clueride.aop.AopModuleTest;
 import com.clueride.domain.account.member.MemberService;
+import com.clueride.domain.account.member.MemberStore;
 import com.clueride.domain.account.principal.EmailPrincipal;
 import com.clueride.domain.account.principal.PrincipalService;
 import com.clueride.domain.account.principal.SessionPrincipal;
 import com.clueride.domain.badge.event.BadgeEventService;
+import com.clueride.domain.badge.event.BadgeEventStore;
 import com.clueride.domain.user.image.ImageStore;
 import com.clueride.domain.user.image.ImageStoreJpa;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -47,10 +49,16 @@ public class DomainGuiceModuleTest extends AbstractModule {
     private BadgeEventService badgeEventService;
 
     @Mock
+    private BadgeEventStore badgeEventStore;
+
+    @Mock
     private ImageStore imageStore;
 
     @Mock
     private MemberService memberService;
+
+    @Mock
+    private MemberStore memberStore;
 
     @Mock
     private PrincipalService principleService;
@@ -72,7 +80,9 @@ public class DomainGuiceModuleTest extends AbstractModule {
         }
         bind(AopDummyService.class).toInstance(dummyService);
         bind(BadgeEventService.class).toInstance(badgeEventService);
+        bind(BadgeEventStore.class).toInstance(badgeEventStore);
         bind(MemberService.class).toInstance(memberService);
+        bind(MemberStore.class).toInstance(memberStore);
         bind(PrincipalService.class).toInstance(principleService);
         bind(SessionPrincipal.class).toInstance(sessionPrincipal);
 
@@ -80,7 +90,7 @@ public class DomainGuiceModuleTest extends AbstractModule {
 
     @Provides
     private Principal getEmailPrincipal() {
-        return new EmailPrincipal("test.dummy@clueride.com");
+        return new EmailPrincipal("test.different@clueride.com");
     }
 
 }

--- a/domain/src/test/java/com/clueride/domain/badge/event/BadgeEventServiceImplTest.java
+++ b/domain/src/test/java/com/clueride/domain/badge/event/BadgeEventServiceImplTest.java
@@ -1,0 +1,206 @@
+package com.clueride.domain.badge.event;/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 11/25/17.
+ */
+
+import java.security.Principal;
+import java.util.Date;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Guice;
+import org.testng.annotations.Test;
+
+import com.clueride.domain.DomainGuiceModuleTest;
+import com.clueride.domain.account.member.Member;
+import com.clueride.domain.account.member.MemberService;
+import com.clueride.domain.account.principal.EmailPrincipal;
+import com.clueride.domain.account.principal.PrincipalService;
+import com.clueride.infrastructure.ClientSourced;
+import com.clueride.infrastructure.DbSourced;
+import com.clueride.infrastructure.ServiceSourced;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Exercises the BadgeEventServiceImplTest class.
+ */
+@Guice(modules = DomainGuiceModuleTest.class)
+public class BadgeEventServiceImplTest {
+    private BadgeEventServiceImpl toTest;
+    private Date sharedTimestamp = new Date();
+
+    @Inject
+    private BadgeEventStore badgeEventStore;
+
+    @Inject
+    private Provider<BadgeEventServiceImpl> toTestProvider;
+
+    @Inject
+    @ClientSourced
+    private BadgeEvent.Builder badgeEventBuilderFromClient;
+
+    @Inject
+    @DbSourced
+    private BadgeEvent.Builder badgeEventBuilderFromDb;
+
+    @Inject
+    @ServiceSourced
+    private BadgeEvent.Builder badgeEventBuilderFromService;
+
+    @Inject
+    private BadgeEvent badgeEvent;
+
+    @Inject
+    private MemberService memberService;
+
+    @Inject
+    private Member member;
+
+    @Inject
+    private PrincipalService principalService;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        reset(
+                badgeEventStore,
+                memberService,
+                principalService
+        );
+        toTest = toTestProvider.get();
+        assertNotNull(toTest);
+    }
+
+    @Test
+    public void testSend() throws Exception {
+        /* setup test */
+
+        /* train mocks */
+        Principal principal = badgeEventBuilderFromClient.getPrincipal();
+        when(memberService.getMemberByEmail(principal.getName())).thenReturn(member);
+
+        /* make call */
+        toTest.send(badgeEventBuilderFromClient);
+
+        /* Allow other thread to complete. */
+        Thread.sleep(100);
+
+        /* verify results */
+        verify(badgeEventStore).add(badgeEventBuilderFromClient);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testSend_null() throws Exception {
+       /* setup test */
+
+       /* train mocks */
+
+       /* make call */
+        toTest.send(null);
+
+        /* Allow other thread to complete. */
+        Thread.sleep(100);
+
+       /* verify results */
+    }
+
+    @Test
+    public void testSend_storeFailure() throws Exception {
+        /* setup test */
+
+        /* train mocks */
+        Principal principal = badgeEventBuilderFromClient.getPrincipal();
+        when(memberService.getMemberByEmail(principal.getName())).thenReturn(member);
+        doThrow(RuntimeException.class).when(badgeEventStore).add(badgeEventBuilderFromClient);
+
+        /* make call */
+        toTest.send(badgeEventBuilderFromClient);
+
+        /* Allow other thread to complete. */
+        Thread.sleep(100);
+
+        /* verify results */
+    }
+
+    /* Population of Transient Fields into/from Columns */
+
+    @Test
+    public void testFillPrincipal() throws Exception {
+        /* setup test */
+        Integer badgeEventId = badgeEvent.getId();
+        Integer memberId = badgeEventBuilderFromDb.getMemberId();
+        Principal alternatePrincipal = new EmailPrincipal("guest.different@clueride.com");
+        BadgeEvent expected = badgeEventBuilderFromService
+                .withId(badgeEventBuilderFromDb.getId())
+                .withTimestamp(sharedTimestamp)
+                .withPrincipal(alternatePrincipal)
+                .build();
+
+        /* train mocks */
+        when(badgeEventStore.getById(badgeEventId)).thenReturn(
+                badgeEventBuilderFromDb
+                        .withTimestamp(sharedTimestamp)
+        );
+        when(memberService.getMember(memberId)).thenReturn(member);
+        when(principalService.getPrincipalForEmailAddress(member.getEmailAddress())).thenReturn(alternatePrincipal);
+
+        /* make call */
+        BadgeEvent actual = toTest.getBadgeEventById(badgeEventId);
+
+        /* verify results */
+        assertEquals(actual.getPrincipal(), expected.getPrincipal());
+    }
+
+    @Test
+    public void testFillBuilder() throws Exception {
+        /* setup test */
+        BadgeEvent.Builder expected = BadgeEvent.Builder.from(badgeEvent)
+                .withMemberId(member.getId())
+                .withTimestamp(sharedTimestamp)
+                .withId(null);
+
+        /* train mocks */
+        Principal principal = badgeEventBuilderFromClient.getPrincipal();
+        when(memberService.getMemberByEmail(principal.getName())).thenReturn(member);
+
+        /* make call */
+        toTest.send(badgeEventBuilderFromClient.withTimestamp(sharedTimestamp));
+
+        /* Allow other thread to complete. */
+        Thread.sleep(100);
+
+        /* verify results */
+        verify(badgeEventStore).add(expected);
+    }
+
+    @Test
+    public void testFrom() throws Exception {
+        /* make call */
+        BadgeEvent.Builder expected = BadgeEvent.Builder.from(badgeEvent);
+
+        /* verify results */
+        assertNotNull(expected.getId());
+        assertNotNull(expected.getReturnValueAsString());
+        assertNotNull(expected.getMemberId());
+        assertNotNull(expected.getClassName());
+    }
+}


### PR DESCRIPTION
* Adds new service for handling sent Badge Captures using worker thread
draining a queue.
* Adds Store for persisting and retrieval by ID of Badge Events.
* Introduces annotations for distinguishing between mutable objects that
originate with the Client, Database, or Service.
* Fixes module for the moved MemberStore.