### PR TITLE
CA-295 Get TypeSafe going for configuration

### DIFF
--- a/crCore/pom.xml
+++ b/crCore/pom.xml
@@ -149,7 +149,7 @@
         <dependency>
             <groupId>com.typesafe</groupId>
             <artifactId>config</artifactId>
-            <version>1.3.1</version>
+            <version>1.2.1</version>
         </dependency>
         <!-- http://mvnrepository.com/artifact/javax.mail/mail -->
         <dependency>

--- a/crCore/src/main/java/com/clueride/config/ConfigService.java
+++ b/crCore/src/main/java/com/clueride/config/ConfigService.java
@@ -17,6 +17,8 @@
  */
 package com.clueride.config;
 
+import java.util.List;
+
 /**
  * Defines interaction with configuration information.
  */
@@ -27,4 +29,8 @@ public interface ConfigService {
      * @return String matching the key.
      */
     String get(String key);
+
+    List<String> getAuthIssuers();
+
+    String getAuthSecret();
 }

--- a/crCore/src/main/java/com/clueride/config/ConfigServiceImpl.java
+++ b/crCore/src/main/java/com/clueride/config/ConfigServiceImpl.java
@@ -17,29 +17,30 @@
  */
 package com.clueride.config;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.List;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 
 /**
  * Interim implementation until I can get the TypeSafe config impl going.
  */
 public class ConfigServiceImpl implements ConfigService {
-    private static Map<String,String> map = new HashMap<>();
+    private static Config config = ConfigFactory.load();
 
-    static {
-        // TODO: Move this secret out of the committed code
-        map.put(
-                "token.jwt.secret",
-                "9QYMlYqGJaO9MLKzrA6Pc_rMX3id8CAeqa5cFPVJGPoUtx8l3vTENv8MGO8Nc4l1"
-        );
-
-        map.put(
-                "token.jwt.issuer",
-                "clueride-social.auth0.com"
-        );
-    }
     @Override
     public String get(String key) {
-        return map.get(key);
+        return config.getString(key);
     }
+
+    @Override
+    public List<String> getAuthIssuers() {
+        return config.getStringList("clueride.jwt.issuers");
+    }
+
+    @Override
+    public String getAuthSecret() {
+        return config.getString("clueride.jwt.secret");
+    }
+
 }

--- a/crCore/src/main/java/com/clueride/token/TokenService.java
+++ b/crCore/src/main/java/com/clueride/token/TokenService.java
@@ -64,10 +64,4 @@ public interface TokenService {
      */
     String getNameFromToken(String token);
 
-    /**
-     * For the given token, retrieve whether or not this is a Guest Token.
-     * @param token to be checked.
-     * @return true if this token represents a guest.
-     */
-    boolean isGuestToken(String token);
 }

--- a/crCore/src/main/resources/reference.conf
+++ b/crCore/src/main/resources/reference.conf
@@ -1,0 +1,9 @@
+clueride {
+    jwt {
+        secret = Replace with the Auth0 secret
+        issuers = [
+            "https://clueride-social.auth0.com/"
+            "https://clueride.auth0.com/"
+        ]
+    }
+}

--- a/crCore/src/test/java/com/clueride/CoreGuiceModuleTest.java
+++ b/crCore/src/test/java/com/clueride/CoreGuiceModuleTest.java
@@ -19,8 +19,6 @@ package com.clueride;
 
 import java.security.Principal;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTCreator;
@@ -49,6 +47,8 @@ import com.clueride.domain.account.member.Member;
 import com.clueride.domain.account.member.MemberService;
 import com.clueride.domain.account.principal.EmailPrincipal;
 import com.clueride.domain.account.principal.PrincipalService;
+import com.clueride.domain.account.principal.SessionPrincipal;
+import com.clueride.domain.account.principal.SessionPrincipalImpl;
 import com.clueride.domain.dev.NetworkProposal;
 import com.clueride.domain.dev.NewNodeProposal;
 import com.clueride.domain.dev.TrackImpl;
@@ -74,7 +74,6 @@ import com.clueride.service.OutingService;
 import com.clueride.service.OutingServiceImpl;
 import com.clueride.service.RecommendationService;
 import com.clueride.service.TeamService;
-import com.clueride.token.CustomClaim;
 import com.clueride.token.JtiService;
 import com.clueride.token.JtiServiceImpl;
 import com.clueride.token.TokenService;
@@ -246,6 +245,11 @@ public class CoreGuiceModuleTest extends AbstractModule {
     }
 
     @Provides
+    private SessionPrincipal getSessionPrincipal() {
+        return new SessionPrincipalImpl();
+    }
+
+    @Provides
     private JWTCreator.Builder getJwtBuilder(
             JtiService jtiService,
             Member member
@@ -253,12 +257,8 @@ public class CoreGuiceModuleTest extends AbstractModule {
         Date now = new Date();
         Date inASecond = new Date(now.getTime() + 1000);
 
-        Map<String, Object> headerClaims = new HashMap<>();
-        headerClaims.put(CustomClaim.BADGES, member.getBadges());
-        headerClaims.put(CustomClaim.EMAIL, member.getEmailAddress());
-
         return JWT.create()
-                .withHeader(headerClaims)
+                .withClaim("email", member.getEmailAddress())
                 .withJWTId(jtiService.registerNewId())
                 .withExpiresAt(inASecond);
     }


### PR DESCRIPTION
* Added Typesafe configuration implementation and reference.conf file.
* The Typesafe dependency needed to be backed down to 1.2.1 to conform
with the Java 7 compile target.
* A number of tests needed to be updated.

Not part of this commit, but within the Tomcat configuration on the test
server is an override application.conf that provides the sensitive data.