### PR TITLE
CA-356 Configure Hibernate for WordPress connections to MySQL DB

### DIFF
--- a/domain/pom.xml
+++ b/domain/pom.xml
@@ -82,6 +82,12 @@
       <artifactId>postgresql</artifactId>
       <version>42.1.4.jre7</version>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/mysql/mysql-connector-java -->
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+      <version>5.1.6</version>
+    </dependency>
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>

--- a/domain/src/main/java/com/clueride/domain/DomainGuiceProviderModule.java
+++ b/domain/src/main/java/com/clueride/domain/DomainGuiceProviderModule.java
@@ -44,6 +44,8 @@ import com.clueride.infrastructure.ClientSourced;
 import com.clueride.infrastructure.DbSourced;
 import com.clueride.infrastructure.JpaUtil;
 import com.clueride.infrastructure.ServiceSourced;
+import com.clueride.infrastructure.db.ClueRide;
+import com.clueride.infrastructure.db.WordPress;
 import static java.util.Arrays.asList;
 
 /**
@@ -56,8 +58,15 @@ public class DomainGuiceProviderModule extends AbstractModule {
     }
 
     @Provides
-    private EntityManager getEntityManager() {
-        return JpaUtil.getEntityManagerFactory().createEntityManager();
+    @ClueRide
+    private EntityManager getClueRideEntityManager() {
+        return JpaUtil.getClueRideEntityManagerFactory().createEntityManager();
+    }
+
+    @Provides
+    @WordPress
+    private EntityManager getWordPressEntityManager() {
+        return JpaUtil.getWordPressEntityManagerFactory().createEntityManager();
     }
 
     @Provides

--- a/domain/src/main/java/com/clueride/domain/account/member/MemberStoreJpa.java
+++ b/domain/src/main/java/com/clueride/domain/account/member/MemberStoreJpa.java
@@ -26,6 +26,7 @@ import javax.inject.Inject;
 import javax.mail.internet.InternetAddress;
 import javax.persistence.EntityManager;
 
+import com.clueride.infrastructure.db.ClueRide;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -35,7 +36,7 @@ public class MemberStoreJpa implements MemberStore {
     private final EntityManager entityManager;
     @Inject
     public MemberStoreJpa(
-            @Nonnull EntityManager entityManager
+            @Nonnull @ClueRide EntityManager entityManager
     ) {
         this.entityManager = requireNonNull(entityManager);
     }

--- a/domain/src/main/java/com/clueride/domain/badge/event/BadgeEventStoreJpa.java
+++ b/domain/src/main/java/com/clueride/domain/badge/event/BadgeEventStoreJpa.java
@@ -17,8 +17,11 @@
  */
 package com.clueride.domain.badge.event;
 
+import javax.annotation.Nonnull;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
+
+import com.clueride.infrastructure.db.ClueRide;
 
 /**
  * Implementation of Badge Event Store for JPA.
@@ -29,7 +32,7 @@ public class BadgeEventStoreJpa implements BadgeEventStore {
 
     @Inject
     public BadgeEventStoreJpa(
-            EntityManager entityManager
+            @Nonnull @ClueRide EntityManager entityManager
     ) {
         this.entityManager = entityManager;
     }

--- a/domain/src/main/java/com/clueride/domain/user/image/ImageStoreJpa.java
+++ b/domain/src/main/java/com/clueride/domain/user/image/ImageStoreJpa.java
@@ -26,6 +26,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.SequenceGenerator;
 
+import com.clueride.infrastructure.db.ClueRide;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -37,7 +38,7 @@ public class ImageStoreJpa implements ImageStore {
 
     @Inject
     public ImageStoreJpa(
-            @Nonnull EntityManager entityManager
+            @Nonnull @ClueRide EntityManager entityManager
     ) {
         this.entityManager = requireNonNull(entityManager, "missing Entity Manager");
     }

--- a/domain/src/main/java/com/clueride/domain/user/latlon/LatLonStoreJpa.java
+++ b/domain/src/main/java/com/clueride/domain/user/latlon/LatLonStoreJpa.java
@@ -24,6 +24,7 @@ import javax.persistence.EntityManager;
 
 import com.google.inject.Inject;
 
+import com.clueride.infrastructure.db.ClueRide;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -34,7 +35,7 @@ public class LatLonStoreJpa implements LatLonStore {
 
     @Inject
     public LatLonStoreJpa(
-            @Nonnull EntityManager entityManager
+            @Nonnull @ClueRide EntityManager entityManager
     ) {
         this.entityManager = requireNonNull(entityManager);
     }

--- a/domain/src/main/java/com/clueride/domain/user/layer/MapLayerStoreJpa.java
+++ b/domain/src/main/java/com/clueride/domain/user/layer/MapLayerStoreJpa.java
@@ -22,6 +22,8 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
 
+import com.clueride.infrastructure.db.ClueRide;
+
 /**
  * JPA-based implementation of Map Layer persistence.
  */
@@ -30,7 +32,7 @@ public class MapLayerStoreJpa implements MapLayerStore {
 
     @Inject
     public MapLayerStoreJpa(
-            EntityManager entityManager
+            @ClueRide EntityManager entityManager
     ) {
         this.entityManager = entityManager;
     }

--- a/domain/src/main/java/com/clueride/domain/user/location/LocationStoreJpa.java
+++ b/domain/src/main/java/com/clueride/domain/user/location/LocationStoreJpa.java
@@ -27,6 +27,7 @@ import javax.persistence.EntityManager;
 
 import com.google.inject.Inject;
 
+import com.clueride.infrastructure.db.ClueRide;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -37,7 +38,7 @@ public class LocationStoreJpa implements LocationStore {
 
     @Inject
     public LocationStoreJpa(
-            @Nonnull EntityManager entityManager
+            @Nonnull @ClueRide EntityManager entityManager
     ) {
         this.entityManager = requireNonNull(entityManager);
     }

--- a/domain/src/main/java/com/clueride/domain/user/loctype/LocationTypeStoreJpa.java
+++ b/domain/src/main/java/com/clueride/domain/user/loctype/LocationTypeStoreJpa.java
@@ -24,6 +24,8 @@ import javax.persistence.EntityManager;
 
 import com.google.inject.Inject;
 
+import com.clueride.infrastructure.db.ClueRide;
+
 /**
  * JPA implementation of the LocationTypeStore (DAO).
  */
@@ -31,7 +33,9 @@ public class LocationTypeStoreJpa implements LocationTypeStore {
     private final EntityManager entityManager;
 
     @Inject
-    public LocationTypeStoreJpa(EntityManager entityManager) {
+    public LocationTypeStoreJpa(
+            @ClueRide EntityManager entityManager
+    ) {
         this.entityManager = entityManager;
     }
 

--- a/domain/src/main/java/com/clueride/domain/user/puzzle/PuzzleStoreJpa.java
+++ b/domain/src/main/java/com/clueride/domain/user/puzzle/PuzzleStoreJpa.java
@@ -24,6 +24,7 @@ import javax.inject.Inject;
 import javax.persistence.EntityManager;
 
 import com.clueride.domain.user.location.Location;
+import com.clueride.infrastructure.db.ClueRide;
 
 /**
  * Implementation of the Puzzle Store.
@@ -33,7 +34,7 @@ public class PuzzleStoreJpa implements PuzzleStore {
     private final EntityManager entityManager;
     @Inject
     public PuzzleStoreJpa(
-            @Nonnull EntityManager entityManager
+            @Nonnull @ClueRide EntityManager entityManager
     ) {
         this.entityManager = entityManager;
     }

--- a/domain/src/main/java/com/clueride/infrastructure/JpaUtil.java
+++ b/domain/src/main/java/com/clueride/infrastructure/JpaUtil.java
@@ -21,22 +21,35 @@ import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 
 /**
- * Allows obtaining the configured factory for the Hibernate Entity Manager.
+ * Allows obtaining the configured factory for the Hibernate Entity Managers.
  */
 public class JpaUtil {
-    private static final String PERSISTENCE_UNIT_NAME = "ClueRidePersistenceUnit";
-    private static EntityManagerFactory factory;
+    private static final String CLUERIDE_PERSISTENCE_UNIT_NAME = "ClueRidePersistenceUnit";
+    private static final String WORDPRESS_PERSISTENCE_UNIT_NAME = "WordPressPersistenceUnit";
+    private static EntityManagerFactory clueRideFactory;
+    private static EntityManagerFactory wordPressFactory;
 
-    public static EntityManagerFactory getEntityManagerFactory() {
-        if (factory == null) {
-            factory = Persistence.createEntityManagerFactory(PERSISTENCE_UNIT_NAME);
+    public static EntityManagerFactory getClueRideEntityManagerFactory() {
+        if (clueRideFactory == null) {
+            clueRideFactory = Persistence.createEntityManagerFactory(CLUERIDE_PERSISTENCE_UNIT_NAME);
         }
-        return factory;
+        return clueRideFactory;
+    }
+
+    public static EntityManagerFactory getWordPressEntityManagerFactory() {
+        if (wordPressFactory == null) {
+            wordPressFactory = Persistence.createEntityManagerFactory(WORDPRESS_PERSISTENCE_UNIT_NAME);
+        }
+        return wordPressFactory;
     }
 
     public static void shutdown() {
-        if (factory != null) {
-            factory.close();
+        if (clueRideFactory != null) {
+            clueRideFactory.close();
+        }
+        if (wordPressFactory != null) {
+            wordPressFactory.close();
         }
     }
+
 }

--- a/domain/src/main/java/com/clueride/infrastructure/db/ClueRide.java
+++ b/domain/src/main/java/com/clueride/infrastructure/db/ClueRide.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 11/26/17.
+ */
+package com.clueride.infrastructure.db;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import com.google.inject.BindingAnnotation;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotation indicating use of the ClueRide-related DB, DataSource, EntityManager.
+ */
+@BindingAnnotation
+@Retention(RUNTIME)
+@Target({TYPE, METHOD, PARAMETER, FIELD})
+public @interface ClueRide {
+}

--- a/domain/src/main/java/com/clueride/infrastructure/db/WordPress.java
+++ b/domain/src/main/java/com/clueride/infrastructure/db/WordPress.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 11/26/17.
+ */
+package com.clueride.infrastructure.db;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import com.google.inject.BindingAnnotation;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotation indicating use of the ClueRide-related DB, DataSource, EntityManager.
+ */
+@BindingAnnotation
+@Retention(RUNTIME)
+@Target({TYPE, METHOD, PARAMETER, FIELD})
+public @interface WordPress {
+}

--- a/domain/src/test/java/com/clueride/infrastructure/JpaUtilTest.java
+++ b/domain/src/test/java/com/clueride/infrastructure/JpaUtilTest.java
@@ -43,7 +43,7 @@ public class JpaUtilTest {
     @BeforeClass
     public void setUp() {
         if (dbAvailable) {
-            entityManagerFactory = JpaUtil.getEntityManagerFactory();
+            entityManagerFactory = JpaUtil.getClueRideEntityManagerFactory();
             System.out.println("Entity Manager opened");
         }
     }

--- a/service/src/main/java/com/clueride/dao/util/PuzzleUtilMain.java
+++ b/service/src/main/java/com/clueride/dao/util/PuzzleUtilMain.java
@@ -26,6 +26,7 @@ import javax.persistence.EntityManager;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Key;
+import com.google.inject.name.Names;
 import org.apache.log4j.Logger;
 
 import com.clueride.config.GeoToolsGuiceModule;
@@ -125,7 +126,7 @@ public class PuzzleUtilMain {
                 new GeoToolsGuiceModule()
         );
 
-        entityManager = injector.getInstance(EntityManager.class);
+        entityManager = injector.getInstance(Key.get(EntityManager.class, Names.named("ClueRide")));
         puzzleStore = injector.getInstance(
                 PuzzleStore.class
         );


### PR DESCRIPTION
- Adds new pair of annotations for distinguishing entity managers for
ClueRide (PostGreSQL) and WordPress (MySQL) DB instances.
- Attaches the @ClueRide annotation to the injected EntityManagers.
- Adds the Provider to the Domain Guice Module.