### PR TITLE
CA-357 DAO Layer for Badge Display

### DIFF
--- a/domain/src/main/java/com/clueride/domain/DomainGuiceModule.java
+++ b/domain/src/main/java/com/clueride/domain/DomainGuiceModule.java
@@ -19,6 +19,8 @@ package com.clueride.domain;
 
 import com.google.inject.AbstractModule;
 
+import com.clueride.domain.account.member.MemberService;
+import com.clueride.domain.account.member.MemberServiceImpl;
 import com.clueride.domain.account.member.MemberStore;
 import com.clueride.domain.account.member.MemberStoreJpa;
 import com.clueride.domain.account.principal.PrincipalService;
@@ -27,6 +29,8 @@ import com.clueride.domain.account.principal.SessionPrincipal;
 import com.clueride.domain.account.principal.SessionPrincipalImpl;
 import com.clueride.domain.badge.BadgeService;
 import com.clueride.domain.badge.BadgeServiceImpl;
+import com.clueride.domain.badge.BadgeStore;
+import com.clueride.domain.badge.BadgeStoreJpa;
 import com.clueride.domain.badge.event.BadgeEventService;
 import com.clueride.domain.badge.event.BadgeEventServiceImpl;
 import com.clueride.domain.badge.event.BadgeEventStore;
@@ -68,6 +72,7 @@ public class DomainGuiceModule extends AbstractModule {
         bind(BadgeService.class).to(BadgeServiceImpl.class);
         bind(BadgeEventService.class).to(BadgeEventServiceImpl.class);
         bind(BadgeEventStore.class).to(BadgeEventStoreJpa.class);
+        bind(BadgeStore.class).to(BadgeStoreJpa.class);
         bind(ImageService.class).to(ImageServiceImpl.class);
         bind(ImageStore.class).to(ImageStoreJpa.class);
         bind(LatLonStore.class).to(LatLonStoreJpa.class);
@@ -76,6 +81,7 @@ public class DomainGuiceModule extends AbstractModule {
         bind(LocationTypeStore.class).to(LocationTypeStoreJpa.class);
         bind(MapLayerService.class).to(MapLayerServiceImpl.class);
         bind(MapLayerStore.class).to(MapLayerStoreJpa.class);
+        bind(MemberService.class).to(MemberServiceImpl.class);
         bind(MemberStore.class).to(MemberStoreJpa.class);
         bind(PrincipalService.class).to(PrincipalServiceImpl.class);
         bind(PuzzleService.class).to(PuzzleServiceImpl.class);

--- a/domain/src/main/java/com/clueride/domain/badge/Badge.java
+++ b/domain/src/main/java/com/clueride/domain/badge/Badge.java
@@ -24,7 +24,11 @@ import javax.annotation.concurrent.Immutable;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.Table;
 import javax.persistence.Transient;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.log4j.Logger;
 
 import static java.util.Objects.requireNonNull;
 
@@ -37,13 +41,15 @@ import static java.util.Objects.requireNonNull;
 @Immutable
 public class Badge {
     private final Integer id;
-    private final BadgeType badgeType;
+    // TODO: CA-359
+//    private final BadgeType badgeType;
     private final URL badgeImageUrl;
     private final URL badgeCriteriaUrl;
 
     public Badge(Builder builder) {
         this.id = requireNonNull(builder.getId());
-        this.badgeType = requireNonNull(builder.getBadgeType());
+        // TODO: CA-359
+//        this.badgeType = requireNonNull(builder.getBadgeType());
         this.badgeImageUrl = requireNonNull(builder.getImageUrl());
         this.badgeCriteriaUrl = requireNonNull(builder.getCriteriaUrl());
     }
@@ -52,9 +58,10 @@ public class Badge {
         return id;
     }
 
-    public BadgeType getBadgeType() {
-        return badgeType;
-    }
+    // TODO: CA-359
+//    public BadgeType getBadgeType() {
+//        return badgeType;
+//    }
 
     public URL getBadgeImageUrl() {
         return badgeImageUrl;
@@ -64,15 +71,26 @@ public class Badge {
         return badgeCriteriaUrl;
     }
 
-    @Entity(name="badge")
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    @Entity(name="badge_display_per_user")
+    @Table(name="badge_display_per_user")
     public static class Builder implements com.clueride.domain.common.Builder<Badge> {
+        private static final Logger LOGGER = Logger.getLogger(Builder.class);
 
         @Id
+        @Column(name="achievement_id")
         private Integer id;
 
-        @Column(name="badge_type") private String badgeTypeString;
-        @Column(name="image_url") private String imageUrlString;
-        @Column(name="criteria_url") private String criteriaUrlString;
+        @Column(name="image_url")
+        private String imageUrlString;
+        @Column(name="url")
+        private String criteriaUrlString;
+
+        @Transient private String badgeTypeString;
 
         @Transient
         private BadgeType badgeType;
@@ -98,6 +116,11 @@ public class Badge {
         }
 
         public URL getImageUrl() {
+            try {
+                this.imageUrl = new URL(this.imageUrlString);
+            } catch (MalformedURLException e) {
+                LOGGER.error(e);
+            }
             return imageUrl;
         }
 
@@ -106,6 +129,11 @@ public class Badge {
             return this;
         }
         public URL getCriteriaUrl() {
+            try {
+                this.criteriaUrl = new URL(this.criteriaUrlString);
+            } catch (MalformedURLException e) {
+                LOGGER.error(e);
+            }
             return criteriaUrl;
         }
 
@@ -147,8 +175,8 @@ public class Badge {
         }
 
         public Builder withImageUrlString(String imageUrlString) throws MalformedURLException {
+            this.imageUrl = new URL(this.imageUrlString);
             this.imageUrlString = imageUrlString;
-            this.imageUrl = new URL(imageUrlString);
             return this;
         }
 
@@ -157,8 +185,8 @@ public class Badge {
         }
 
         public Builder withCriteriaUrlString(String criteriaUrlString) throws MalformedURLException {
+            this.criteriaUrl = new URL(this.criteriaUrlString);
             this.criteriaUrlString = criteriaUrlString;
-            this.criteriaUrl = new URL(criteriaUrlString);
             return this;
         }
     }

--- a/domain/src/main/java/com/clueride/domain/badge/BadgeService.java
+++ b/domain/src/main/java/com/clueride/domain/badge/BadgeService.java
@@ -19,8 +19,6 @@ package com.clueride.domain.badge;
 
 import java.util.List;
 
-import com.clueride.domain.user.Badge;
-
 /**
  * Defines what operations are provided for Badges.
  */

--- a/domain/src/main/java/com/clueride/domain/badge/BadgeStore.java
+++ b/domain/src/main/java/com/clueride/domain/badge/BadgeStore.java
@@ -13,30 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
- * Created by jett on 1/16/18.
+ * Created by jett on 8/26/18.
  */
 package com.clueride.domain.badge;
 
 import java.util.List;
 
-import javax.inject.Inject;
-
 /**
- * Default Implementation of BadgeService.
+ * Defines the DAO for Badges.
+ *
+ * Badges are created and maintained within the BadgeOS system and for that reason,
+ * when we read Badges from the database, we're reading from the BadgeOS / WordPress
+ * database.
  */
-public class BadgeServiceImpl implements BadgeService {
-    private final BadgeStore badgeStore;
-
-    @Inject
-    public BadgeServiceImpl(
-            BadgeStore badgeStore
-    ) {
-        this.badgeStore = badgeStore;
-    }
-
-    @Override
-    public List<Badge> getBadges() {
-        return badgeStore.getAwardedBadgesForUser();
-    }
+public interface BadgeStore {
+    /**
+     * Retrieves list of currently awarded badges for the session's user.
+     * @return List of Badges for display.
+     */
+    List<Badge> getAwardedBadgesForUser();
 
 }

--- a/domain/src/main/java/com/clueride/domain/badge/BadgeStoreJpa.java
+++ b/domain/src/main/java/com/clueride/domain/badge/BadgeStoreJpa.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 8/26/18.
+ */
+package com.clueride.domain.badge;
+
+import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+
+import org.apache.log4j.Logger;
+
+import com.clueride.infrastructure.db.WordPress;
+
+/**
+ * JPA implementation of Badge Store.
+ */
+public class BadgeStoreJpa implements BadgeStore {
+    private static final Logger LOGGER = Logger.getLogger(BadgeStoreJpa.class);
+    private final EntityManager entityManager;
+
+    @Inject
+    public BadgeStoreJpa(
+            @Nonnull @WordPress EntityManager entityManager
+    ) {
+        this.entityManager = entityManager;
+    }
+
+    @Override
+    public List<Badge> getAwardedBadgesForUser() {
+        List<Badge.Builder> builderList;
+        entityManager.getTransaction().begin();
+        builderList = entityManager.createQuery(
+                    "SELECT b FROM badge_display_per_user b"
+        ).getResultList();
+        entityManager.getTransaction().commit();
+        List<Badge> badgeList = new ArrayList<>();
+        for (Badge.Builder builder : builderList) {
+            try {
+                badgeList.add(builder.build());
+            } catch (MalformedURLException e) {
+                LOGGER.error("Problem with URL: " + e);
+            }
+        }
+        return badgeList;
+    }
+
+}

--- a/domain/src/test/java/com/clueride/domain/badge/BadgeTest.java
+++ b/domain/src/test/java/com/clueride/domain/badge/BadgeTest.java
@@ -50,7 +50,8 @@ public class BadgeTest {
         toTest = builder.build();
         assertNotNull(toTest);
         assertNotNull(toTest.getId());
-        assertNotNull(toTest.getBadgeType());
+        // TODO: CA-359
+//        assertNotNull(toTest.getBadgeType());
         assertNotNull(toTest.getBadgeImageUrl());
         assertNotNull(toTest.getBadgeCriteriaUrl());
     }
@@ -104,18 +105,19 @@ public class BadgeTest {
         toTest = toTestBuilder.build();
     }
 
-    @Test
-    public void testGetBadgeType_OK() throws Exception {
-        BadgeType expected = BadgeType.GUIDE;
-        toTest = builder.withBadgeTypeString(expected.toString()).build();
-        BadgeType actual = toTest.getBadgeType();
-        assertEquals(actual, expected);
-    }
+    // TODO: CA-359
+//    @Test
+//    public void testGetBadgeType_OK() throws Exception {
+//        BadgeType expected = BadgeType.GUIDE;
+//        toTest = builder.withBadgeTypeString(expected.toString()).build();
+//        BadgeType actual = toTest.getBadgeType();
+//        assertEquals(actual, expected);
+//    }
 
-    @Test(expectedExceptions = IllegalArgumentException.class)
-    public void testGetBadgeType_unrecognizedType() throws Exception {
-        toTest = builder.withBadgeTypeString("not a real badge").build();
-    }
+//    @Test(expectedExceptions = IllegalArgumentException.class)
+//    public void testGetBadgeType_unrecognizedType() throws Exception {
+//        toTest = builder.withBadgeTypeString("not a real badge").build();
+//    }
 
     @Test
     public void testGetBadgeImageUrl_OK() throws Exception {

--- a/service/src/main/java/com/clueride/dao/util/BadgeUtilMain.java
+++ b/service/src/main/java/com/clueride/dao/util/BadgeUtilMain.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 8/27/18.
+ */
+package com.clueride.dao.util;
+
+import java.util.List;
+
+import javax.persistence.EntityManager;
+
+import com.clueride.domain.badge.Badge;
+import com.clueride.domain.badge.BadgeService;
+import com.clueride.domain.badge.BadgeServiceImpl;
+import com.clueride.domain.badge.BadgeStore;
+import com.clueride.domain.badge.BadgeStoreJpa;
+import com.clueride.infrastructure.JpaUtil;
+
+/**
+ * Dumps records from BadgeOS database.
+ */
+public class BadgeUtilMain {
+    private static BadgeService badgeService;
+    private static EntityManager entityManager;
+    private static BadgeStore badgeStore;
+
+    public static void main(String[] args) {
+        try {
+            instantiateServices();
+            List<Badge> badges = badgeService.getBadges();
+            for (Badge badge : badges) {
+                System.out.println(badge.toString());
+            }
+        } finally {
+            entityManager.close();
+        }
+
+        System.exit(0);
+    }
+
+    private static void instantiateServices() {
+        entityManager = JpaUtil.getWordPressEntityManagerFactory().createEntityManager();
+        badgeStore = new BadgeStoreJpa(entityManager);
+        badgeService = new BadgeServiceImpl(badgeStore);
+    }
+}

--- a/service/src/main/java/com/clueride/dao/util/PuzzleUtilMain.java
+++ b/service/src/main/java/com/clueride/dao/util/PuzzleUtilMain.java
@@ -126,7 +126,12 @@ public class PuzzleUtilMain {
                 new GeoToolsGuiceModule()
         );
 
-        entityManager = injector.getInstance(Key.get(EntityManager.class, Names.named("ClueRide")));
+        entityManager = injector.getInstance(
+                Key.get(
+                        EntityManager.class,
+                        Names.named("ClueRide")
+                )
+        );
         puzzleStore = injector.getInstance(
                 PuzzleStore.class
         );


### PR DESCRIPTION
- Adds BadgeStore and JPA implementation with WordPress Entity Manager.
- Updates BadgeService to use new BadgeStore.
- Adds BadgeUtilMain to exercise the retrieval of records from the Store.

Work to map the BadgeType will happen under CA-359.