### PR TITLE
CA-367 Prepare for, implement and test Write access to a wp_users tab…

### DIFF
--- a/domain/src/main/java/com/clueride/domain/DomainGuiceModule.java
+++ b/domain/src/main/java/com/clueride/domain/DomainGuiceModule.java
@@ -31,6 +31,10 @@ import com.clueride.domain.account.principal.PrincipalService;
 import com.clueride.domain.account.principal.PrincipalServiceImpl;
 import com.clueride.domain.account.principal.SessionPrincipal;
 import com.clueride.domain.account.principal.SessionPrincipalImpl;
+import com.clueride.domain.account.wpuser.WpUserService;
+import com.clueride.domain.account.wpuser.WpUserServiceImpl;
+import com.clueride.domain.account.wpuser.WpUserStore;
+import com.clueride.domain.account.wpuser.WpUserStoreJpa;
 import com.clueride.domain.badge.BadgeService;
 import com.clueride.domain.badge.BadgeServiceImpl;
 import com.clueride.domain.badge.BadgeStore;
@@ -98,6 +102,8 @@ public class DomainGuiceModule extends AbstractModule {
         bind(ScoredLocationService.class).to(ScoredLocationServiceImpl.class);
         bind(SessionPrincipal.class).to(SessionPrincipalImpl.class);
         bind(TetherService.class).to(TetherServiceImpl.class);
+        bind(WpUserService.class).to(WpUserServiceImpl.class);
+        bind(WpUserStore.class).to(WpUserStoreJpa.class);
     }
 
 }

--- a/domain/src/main/java/com/clueride/domain/DomainGuiceProviderModule.java
+++ b/domain/src/main/java/com/clueride/domain/DomainGuiceProviderModule.java
@@ -19,6 +19,7 @@ package com.clueride.domain;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -31,6 +32,7 @@ import com.google.inject.Provides;
 
 import com.clueride.domain.account.member.Member;
 import com.clueride.domain.account.principal.EmailPrincipal;
+import com.clueride.domain.account.wpuser.WpUser;
 import com.clueride.domain.badge.event.BadgeEvent;
 import com.clueride.domain.user.Badge;
 import com.clueride.domain.user.answer.Answer;
@@ -51,6 +53,8 @@ import com.clueride.infrastructure.db.WordPress;
  * Guice Providers that may be pulled into Tests of other modules.
  */
 public class DomainGuiceProviderModule extends AbstractModule {
+    private static Date testDateNow = new Date();
+
     @Override
     protected void configure() {
 
@@ -239,5 +243,19 @@ public class DomainGuiceProviderModule extends AbstractModule {
                 .withBadgeLevel("adept")
                 .withBaseUrlString("http://clueride.com/?post_id=3376")
                 .withImageUrlString("http://clueride.com/favicon.ico");
+    }
+
+    @Provides
+    @DbSourced
+    private WpUser.Builder getDbWpUserBuilder() {
+        return WpUser.Builder.builder()
+                .withId(2)
+                .withAccountName("turtle")
+                .withDisplayName("turtle")
+                .withEmailString("turtle@clueride.com")
+                .withWebsiteString("https://clueride.com/turtle")
+                .withActivatedTimestamp(
+                        new Timestamp(testDateNow.getTime())
+                );
     }
 }

--- a/domain/src/main/java/com/clueride/domain/account/wpuser/WpUser.java
+++ b/domain/src/main/java/com/clueride/domain/account/wpuser/WpUser.java
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 9/1/18.
+ */
+package com.clueride.domain.account.wpuser;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.sql.Timestamp;
+
+import javax.annotation.concurrent.Immutable;
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+
+import com.google.common.base.Strings;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * POJO for WordPerfect Users to/from the BadgeOS system.
+ *
+ * There is a BadgeOSPrincipal which also hits the same table, but that is a limited
+ * set of data -- which can be built from the validated data within this class.
+ */
+@Immutable
+public class WpUser {
+    private final Integer id;
+    private final String accountName;
+    private final String displayName;
+    private final String firstName;
+    private final String lastName;
+    private final InternetAddress email;
+    private final URL website;
+    private final Timestamp activatedTimestamp;
+
+    public WpUser(Builder builder) {
+        this.id = requireNonNull(builder.getId());
+        this.accountName = requireNonNull(builder.getAccountName());
+        this.displayName = requireNonNull(builder.getDisplayName());
+        this.firstName = builder.getFirstName();
+        this.lastName = builder.getLastName();
+        this.email = requireNonNull(builder.getEmail());
+        this.website = builder.getWebsite();
+        this.activatedTimestamp = requireNonNull(builder.getActivatedTimestamp());
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public String getAccountName() {
+        return accountName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public InternetAddress getEmail() {
+        return email;
+    }
+
+    public URL getWebsite() {
+        return website;
+    }
+
+    public Timestamp getActivatedTimestamp() {
+        return activatedTimestamp;
+    }
+
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return EqualsBuilder.reflectionEquals(this, obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Entity(name="wp_users")
+    @Table(name="wp_users")
+    public static class Builder {
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        private Integer id;
+
+        @Column(name="user_login")
+        private String accountName;
+
+        @Column(name="user_nicename")
+        private String displayName;
+
+        @Column(name="user_email")
+        private String emailString;
+
+        @Transient private InternetAddress email;
+
+        @Column(name="user_url")
+        private String websiteString;
+
+        @Transient private URL website;
+
+        @Column(name="user_registered")
+        private Timestamp activatedTimestamp;
+
+        @Transient private String firstName;
+        @Transient private String lastName;
+
+        public WpUser build() {
+            return new WpUser(this);
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public static Builder from(WpUser wpUser) {
+            return builder()
+                    .withId(wpUser.getId())
+                    .withAccountName(wpUser.getAccountName())
+                    .withDisplayName(wpUser.getDisplayName())
+                    .withEmail(wpUser.getEmail())
+                    .withFirstName(wpUser.getFirstName())
+                    .withLastName(wpUser.getLastName())
+                    .withWebsite(wpUser.getWebsite())
+                    .withActivatedTimestamp(wpUser.getActivatedTimestamp());
+        }
+
+        public Integer getId() {
+            return id;
+        }
+
+        public Builder withId(Integer id) {
+            this.id = id;
+            return this;
+        }
+
+        public String getAccountName() {
+            return accountName;
+        }
+
+        public Builder withAccountName(String accountName) {
+            this.accountName = accountName;
+            return this;
+        }
+
+        public String getDisplayName() {
+            return displayName;
+        }
+
+        public Builder withDisplayName(String displayName) {
+            this.displayName = displayName;
+            return this;
+        }
+
+        public String getFirstName() {
+            return firstName;
+        }
+
+        public Builder withFirstName(String firstName) {
+            this.firstName = firstName;
+            return this;
+        }
+
+        public String getLastName() {
+            return lastName;
+        }
+
+        public Builder withLastName(String lastName) {
+            this.lastName = lastName;
+            return this;
+        }
+
+        public InternetAddress getEmail() {
+            try {
+                this.email = new InternetAddress(this.emailString);
+            } catch (AddressException e) {
+                e.printStackTrace();
+            }
+            return email;
+        }
+
+        public Builder withEmail(InternetAddress email) {
+            this.email = email;
+            this.emailString = email.getAddress();
+            return this;
+        }
+
+        public Builder withEmailString(String emailString) {
+            this.emailString = emailString;
+            return this;
+        }
+
+        public URL getWebsite() {
+            if (Strings.isNullOrEmpty(this.websiteString)) {
+                return null;
+            }
+
+            try {
+                this.website = new URL(this.websiteString);
+            } catch (MalformedURLException e) {
+                e.printStackTrace();
+            }
+            return website;
+        }
+
+        public Builder withWebsite(URL website) {
+            this.website = website;
+            this.websiteString = website.toString();
+            return this;
+        }
+
+        public String getWebsiteString() {
+            return websiteString;
+        }
+
+        public Builder withWebsiteString(String websiteString) {
+            this.websiteString = websiteString;
+            return this;
+        }
+
+        public Timestamp getActivatedTimestamp() {
+            return activatedTimestamp;
+        }
+
+        public Builder withActivatedTimestamp(Timestamp activatedTimestamp) {
+            this.activatedTimestamp = activatedTimestamp;
+            return this;
+        }
+
+    }
+
+}

--- a/domain/src/main/java/com/clueride/domain/account/wpuser/WpUserService.java
+++ b/domain/src/main/java/com/clueride/domain/account/wpuser/WpUserService.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 9/1/18.
+ */
+package com.clueride.domain.account.wpuser;
+
+import com.clueride.domain.account.principal.EmailPrincipal;
+
+/**
+ * Manages WordPress User account information.
+ */
+public interface WpUserService {
+
+    /**
+     * Given an Email Address (wrapped in a Principal object), provide the matching WordPress and BadgeOS User Account
+     * information.
+     * @return WpUser record matching the email address.
+     */
+    WpUser getUserByEmail(EmailPrincipal emailPrincipal);
+
+    /**
+     * Given a fully-populated WpUser instance, persist this to the BadgeOS system.
+     * @param wpUser to be created.
+     * @return The instance with an ID from the database.
+     */
+    WpUser createUser(WpUser.Builder wpUser);
+
+}

--- a/domain/src/main/java/com/clueride/domain/account/wpuser/WpUserServiceImpl.java
+++ b/domain/src/main/java/com/clueride/domain/account/wpuser/WpUserServiceImpl.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 9/1/18.
+ */
+package com.clueride.domain.account.wpuser;
+
+import java.sql.Timestamp;
+import java.util.Date;
+
+import javax.inject.Inject;
+
+import com.clueride.domain.account.principal.EmailPrincipal;
+
+/**
+ * Default implementation of WpUser Service.
+ */
+public class WpUserServiceImpl implements WpUserService {
+    private final WpUserStore wpUserStore;
+
+    @Inject
+    public WpUserServiceImpl(
+            WpUserStore wpUserStore
+    ) {
+        this.wpUserStore = wpUserStore;
+    }
+
+    @Override
+    public WpUser getUserByEmail(EmailPrincipal emailPrincipal) {
+        return this.wpUserStore.getWpUser(emailPrincipal).build();
+    }
+
+    @Override
+    public WpUser createUser(WpUser.Builder wpUser) {
+        /* Don't care what we've been told, we're using our own timestamp for creation. */
+        wpUser.withActivatedTimestamp(new Timestamp(new Date().getTime()));
+        return this.wpUserStore.createWpUser(wpUser).build();
+    }
+
+}

--- a/domain/src/main/java/com/clueride/domain/account/wpuser/WpUserStore.java
+++ b/domain/src/main/java/com/clueride/domain/account/wpuser/WpUserStore.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 9/1/18.
+ */
+package com.clueride.domain.account.wpuser;
+
+import com.clueride.domain.account.principal.EmailPrincipal;
+
+/**
+ * Knows how to persist and retrieve WordPress User instances.
+ */
+public interface WpUserStore {
+
+    /**
+     * Given an Email Address (wrapped in an EmailPrincipal), provide the matching WordPress / BadgeOS info.
+     * @param emailPrincipal representing a particular email address.
+     * @return Builder for the WpUser class.
+     */
+    WpUser.Builder getWpUser(EmailPrincipal emailPrincipal);
+
+    /**
+     * Create new set of records for the given WordPress User instance.
+     * @param builder mutable object representing complete set of data we have on this User.
+     * @return the instance originally passed in.
+     */
+    WpUser.Builder createWpUser(WpUser.Builder builder);
+
+}

--- a/domain/src/main/java/com/clueride/domain/account/wpuser/WpUserStoreJpa.java
+++ b/domain/src/main/java/com/clueride/domain/account/wpuser/WpUserStoreJpa.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 9/1/18.
+ */
+package com.clueride.domain.account.wpuser;
+
+import javax.persistence.EntityManager;
+
+import org.apache.log4j.Logger;
+
+import com.clueride.domain.account.principal.EmailPrincipal;
+import com.clueride.infrastructure.db.WordPress;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * JPA Implementation of WpUser persistence.
+ */
+public class WpUserStoreJpa implements WpUserStore {
+    private static final Logger LOGGER = Logger.getLogger(WpUserStoreJpa.class);
+    private final EntityManager entityManager;
+
+    public WpUserStoreJpa(
+            @WordPress EntityManager entityManager
+    ) {
+        this.entityManager = requireNonNull(entityManager);
+    }
+
+    @Override
+    public WpUser.Builder getWpUser(EmailPrincipal emailPrincipal) {
+        requireNonNull(emailPrincipal);
+
+        String emailAddress = emailPrincipal.getName();
+        LOGGER.debug("Looking up for email address " + emailAddress);
+        entityManager.getTransaction().begin();
+        WpUser.Builder builder = entityManager.createQuery(
+                "FROM wp_users WHERE user_email = :email",
+                WpUser.Builder.class
+        )
+                .setParameter("email", emailAddress)
+                .getSingleResult();
+        entityManager.getTransaction().commit();
+        return builder;
+    }
+
+    @Override
+    public WpUser.Builder createWpUser(WpUser.Builder builder) {
+        requireNonNull(builder);
+        entityManager.getTransaction().begin();
+        entityManager.persist(builder);
+        entityManager.getTransaction().commit();
+        return builder;
+    }
+
+}

--- a/domain/src/main/java/com/clueride/domain/badge/BadgeStoreJpa.java
+++ b/domain/src/main/java/com/clueride/domain/badge/BadgeStoreJpa.java
@@ -46,7 +46,7 @@ public class BadgeStoreJpa implements BadgeStore {
         List<Badge.Builder> builderList;
         entityManager.getTransaction().begin();
         builderList = entityManager.createQuery(
-                    "SELECT b FROM badge_display_per_user b where user_id = :userId"
+                    "SELECT b FROM badge_display_per_user b WHERE user_id = :userId"
         )
                 .setParameter("userId", userId)
                 .getResultList();

--- a/domain/src/test/java/com/clueride/domain/DomainGuiceModuleTest.java
+++ b/domain/src/test/java/com/clueride/domain/DomainGuiceModuleTest.java
@@ -36,6 +36,7 @@ import com.clueride.domain.account.principal.BadgeOsPrincipalService;
 import com.clueride.domain.account.principal.EmailPrincipal;
 import com.clueride.domain.account.principal.PrincipalService;
 import com.clueride.domain.account.principal.SessionPrincipal;
+import com.clueride.domain.account.wpuser.WpUserStore;
 import com.clueride.domain.badge.Badge;
 import com.clueride.domain.badge.BadgeStore;
 import com.clueride.domain.badge.BadgeType;
@@ -85,6 +86,9 @@ public class DomainGuiceModuleTest extends AbstractModule {
     @Mock
     private SessionPrincipal sessionPrincipal;
 
+    @Mock
+    private WpUserStore wpUserStore;
+
     @Override
     protected void configure() {
         initMocks(this);
@@ -107,6 +111,7 @@ public class DomainGuiceModuleTest extends AbstractModule {
         bind(MemberStore.class).toInstance(memberStore);
         bind(PrincipalService.class).toInstance(principleService);
         bind(SessionPrincipal.class).toInstance(sessionPrincipal);
+        bind(WpUserStore.class).toInstance(wpUserStore);
 
     }
 

--- a/domain/src/test/java/com/clueride/domain/account/wpuser/WpUserServiceImplTest.java
+++ b/domain/src/test/java/com/clueride/domain/account/wpuser/WpUserServiceImplTest.java
@@ -1,0 +1,53 @@
+package com.clueride.domain.account.wpuser;/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 9/1/18.
+ */
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Guice;
+import org.testng.annotations.Test;
+
+import com.clueride.domain.DomainGuiceModuleTest;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Exercises the WpUserServiceImplTest class.
+ */
+@Guice(modules = DomainGuiceModuleTest.class)
+public class WpUserServiceImplTest {
+    private WpUserServiceImpl toTest;
+
+    @Inject
+    private Provider<WpUserServiceImpl> toTestProvider;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        toTest = toTestProvider.get();
+        assertNotNull(toTest);
+    }
+
+    @Test
+    public void testGetUserByEmail() throws Exception {
+    }
+
+    @Test
+    public void testCreateUser() throws Exception {
+    }
+
+}

--- a/domain/src/test/java/com/clueride/domain/account/wpuser/WpUserTest.java
+++ b/domain/src/test/java/com/clueride/domain/account/wpuser/WpUserTest.java
@@ -1,0 +1,50 @@
+package com.clueride.domain.account.wpuser;/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 9/1/18.
+ */
+
+import javax.inject.Inject;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Guice;
+import org.testng.annotations.Test;
+
+import com.clueride.domain.DomainGuiceModuleTest;
+import com.clueride.infrastructure.DbSourced;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Exercises the WpUserTest class.
+ */
+@Guice(modules= DomainGuiceModuleTest.class)
+public class WpUserTest {
+
+    @Inject
+    @DbSourced
+    private WpUser.Builder wpUserBuilder;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+    }
+
+    @Test
+    public void testEquals() throws Exception {
+        WpUser expected = wpUserBuilder.build();
+        WpUser actual = WpUser.Builder.from(expected).build();
+        assertEquals(actual, expected);
+    }
+
+}

--- a/service/src/main/java/com/clueride/dao/util/WpUserUtilMain.java
+++ b/service/src/main/java/com/clueride/dao/util/WpUserUtilMain.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 Jett Marks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Created by jett on 9/1/18.
+ */
+package com.clueride.dao.util;
+
+import java.util.Date;
+
+import javax.persistence.EntityManager;
+
+import com.clueride.domain.account.principal.EmailPrincipal;
+import com.clueride.domain.account.wpuser.WpUser;
+import com.clueride.domain.account.wpuser.WpUserService;
+import com.clueride.domain.account.wpuser.WpUserServiceImpl;
+import com.clueride.domain.account.wpuser.WpUserStore;
+import com.clueride.domain.account.wpuser.WpUserStoreJpa;
+import com.clueride.infrastructure.JpaUtil;
+
+/**
+ * Utility for matching up between Member and WpUser.
+ *
+ * And for command-line stuff.
+ */
+public class WpUserUtilMain {
+    private static EntityManager entityManager;
+    private static WpUserService wpUserService;
+    private static WpUserStore wpUserStore;
+
+    public static void main(String[] args) {
+        try {
+            instantiateServices();
+            EmailPrincipal emailPrincipal = new EmailPrincipal("uname3@clueride.com");
+            WpUser user = wpUserService.getUserByEmail(emailPrincipal);
+            System.out.println(user);
+
+            System.out.println("\nCreating new record\n");
+
+            String baseName = "tName-" + (new Date().getTime() % 100000);
+            WpUser.Builder builder = WpUser.Builder.builder()
+                    .withAccountName(baseName)
+                    .withDisplayName(baseName)
+                    .withEmailString(baseName+"@clueride.com")
+                    .withWebsiteString("https://clueride.com/" + baseName);
+            WpUser savedUser = wpUserService.createUser(builder);
+            System.out.println("New User: " + savedUser);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        } finally {
+            entityManager.close();
+        }
+        System.exit(0);
+    }
+
+    private static void instantiateServices() {
+        entityManager = JpaUtil.getWordPressEntityManagerFactory().createEntityManager();
+        wpUserStore = new WpUserStoreJpa(entityManager);
+        wpUserService = new WpUserServiceImpl(wpUserStore);
+    }
+
+}


### PR DESCRIPTION
…le via Hibernate

- Adds Store and Service layers for a new WpUser class representing WordPress Users.
This class is (mostly) independent of BadgeOS.

Full creation of the user account requires population of "meta" records which is not performed by
this store, but may be performed by the Service layer talking with a separate Store.