### PR TITLE
CA-337 Turn down the level of logging out of Hibernate

### DIFF
--- a/clueride/src/main/resources/log4j.properties
+++ b/clueride/src/main/resources/log4j.properties
@@ -1,8 +1,15 @@
-log4j.rootLogger=DEBUG,stdout
+log4j.rootLogger=DEBUG,stdout,file
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 # log4j.appender.stdout.layout.ConversionPattern=%d [%t] %-5p %c - %m%n
 log4j.appender.stdout.layout.ConversionPattern=%d [%c] %-5p - %m%n
+
+log4j.appender.file=org.apache.log4j.RollingFileAppender
+log4j.appender.file.File=/tmp/clueride.log
+log4j.appender.file.MaxFileSize=1MB
+log4j.appender.file.MaxBackupIndex=10
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d [%c] %-5p - %m%n
 
 log4j.logger.com.clueride.io=INFO
 log4j.logger.org.geotools.feature.DefaultFeatureCollection=ERROR

--- a/crMain/src/main/resources/log4j.properties
+++ b/crMain/src/main/resources/log4j.properties
@@ -1,8 +1,15 @@
-log4j.rootLogger=DEBUG,stdout
+log4j.rootLogger=DEBUG,stdout,file
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 # log4j.appender.stdout.layout.ConversionPattern=%d [%t] %-5p %c - %m%n
 log4j.appender.stdout.layout.ConversionPattern=%d [%c] %-5p - %m%n
+
+log4j.appender.file=org.apache.log4j.RollingFileAppender
+log4j.appender.file.File=/tmp/clueride.log
+log4j.appender.file.MaxFileSize=1MB
+log4j.appender.file.MaxBackupIndex=10
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d [%c] %-5p - %m%n
 
 log4j.logger.com.clueride.io=INFO
 log4j.logger.org.geotools.feature.DefaultFeatureCollection=ERROR


### PR DESCRIPTION
- Moves the relevant Clue Ride logging to its own file under /tmp
(was having permissions issues with the default location -- whatever that is)

NOTE: There are other applications using Hibernate and they will set their
own logging levels within `catalina.out`.