### PR TITLE
CA-367 Prepare for, implement and test Write access to a wp_users tab…

### DIFF
--- a/domain/src/main/java/com/clueride/domain/account/principal/BadgeOsPrincipal.java
+++ b/domain/src/main/java/com/clueride/domain/account/principal/BadgeOsPrincipal.java
@@ -25,6 +25,7 @@ import javax.mail.internet.InternetAddress;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.Table;
 import javax.persistence.Transient;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -76,7 +77,8 @@ public class BadgeOsPrincipal implements Principal {
         return ToStringBuilder.reflectionToString(this);
     }
 
-    @Entity(name="wp_users")
+    @Entity(name="badgeos_principal")
+    @Table(name="wp_users")
     public static class Builder implements com.clueride.domain.common.Builder {
         /**
          * Builder for BadgeOsPrincipal.

--- a/domain/src/main/java/com/clueride/domain/account/principal/BadgeOsPrincipalStoreJpa.java
+++ b/domain/src/main/java/com/clueride/domain/account/principal/BadgeOsPrincipalStoreJpa.java
@@ -47,7 +47,7 @@ public class BadgeOsPrincipalStoreJpa implements BadgeOsPrincipalStore {
 
             principalBuilder = entityManager
                     .createQuery(
-                            "from wp_users u where u.emailAddressString = :emailAddress",
+                            "from badgeos_principal p where p.emailAddressString = :emailAddress",
                             BadgeOsPrincipal.Builder.class
                     )
                     .setParameter("emailAddress", emailAddress.toString())

--- a/domain/src/main/java/com/clueride/domain/account/wpuser/WpUserStoreJpa.java
+++ b/domain/src/main/java/com/clueride/domain/account/wpuser/WpUserStoreJpa.java
@@ -17,6 +17,7 @@
  */
 package com.clueride.domain.account.wpuser;
 
+import javax.inject.Inject;
 import javax.persistence.EntityManager;
 
 import org.apache.log4j.Logger;
@@ -32,6 +33,7 @@ public class WpUserStoreJpa implements WpUserStore {
     private static final Logger LOGGER = Logger.getLogger(WpUserStoreJpa.class);
     private final EntityManager entityManager;
 
+    @Inject
     public WpUserStoreJpa(
             @WordPress EntityManager entityManager
     ) {

--- a/service/src/main/java/com/clueride/dao/util/BadgeUtilMain.java
+++ b/service/src/main/java/com/clueride/dao/util/BadgeUtilMain.java
@@ -19,8 +19,11 @@ package com.clueride.dao.util;
 
 import java.util.List;
 
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
 import javax.persistence.EntityManager;
 
+import com.clueride.domain.account.principal.BadgeOsPrincipal;
 import com.clueride.domain.account.principal.SessionPrincipal;
 import com.clueride.domain.account.principal.SessionPrincipalImpl;
 import com.clueride.domain.badge.Badge;
@@ -47,6 +50,8 @@ public class BadgeUtilMain {
             for (Badge badge : badges) {
                 System.out.println(badge.toString());
             }
+        } catch (Exception e) {
+            e.printStackTrace();
         } finally {
             entityManager.close();
         }
@@ -59,6 +64,23 @@ public class BadgeUtilMain {
         badgeStore = new BadgeStoreJpa(entityManager);
         BadgeTypeService badgeTypeService = new BadgeTypeServiceMappedImpl();
         SessionPrincipal sessionPrincipal = new SessionPrincipalImpl();
+        setUserSession(sessionPrincipal);
         badgeService = new BadgeServiceImpl(badgeStore, badgeTypeService, sessionPrincipal);
+
+    }
+
+    private static void setUserSession(SessionPrincipal sessionPrincipal) {
+        InternetAddress emailAddress = null;
+        try {
+            emailAddress = new InternetAddress("bikeangel.atl@gmail.com");
+        } catch (AddressException e) {
+            e.printStackTrace();
+        }
+        BadgeOsPrincipal badgeOsPrincipal = BadgeOsPrincipal.Builder.builder()
+                .withName("don't care")
+                .withEmailAddress(emailAddress)
+                .withBadgeOsUserId(47)
+                .build();
+        sessionPrincipal.setSessionPrincipal(badgeOsPrincipal);
     }
 }


### PR DESCRIPTION
…le via Hibernate

- Adds Store and Service layers for a new WpUser class representing WordPress Users.
This class is (mostly) independent of BadgeOS.

Full creation of the user account requires population of "meta" records which is not performed by
this store, but may be performed by the Service layer talking with a separate Store.

Learned that the persistence language expects entity names and if we have two different entities
going against the same table, we need to expressly map to that table using two different entity
names.